### PR TITLE
Fix styling of Navbar and Links 

### DIFF
--- a/vera-react-app/src/components/Footer/Footer.css
+++ b/vera-react-app/src/components/Footer/Footer.css
@@ -54,7 +54,7 @@
     }
 }
 
-a{
+.footer-links{
     color: white;
     cursor: pointer;
     text-decoration: none;
@@ -67,6 +67,11 @@ a{
     }
 }
 
-a:hover{
+.footer-links:hover{
     text-decoration: underline;
+    color: white;
+}
+
+.footer-links:after{
+    color:white;
 }

--- a/vera-react-app/src/components/Footer/Footer.js
+++ b/vera-react-app/src/components/Footer/Footer.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import './Footer.css';
+import { Link } from "react-router-dom";
 
 function Footer() {
     return (
@@ -8,8 +9,8 @@ function Footer() {
                 &copy; 2020 VERA
             </div>
             <div className="column3">
-                <a href="Recourses.html"> Resources </a> 
-                <a href="Stories.html"> Stories </a>
+                <Link className="footer-links" to = "/Resources"> Resources </Link> 
+                <Link className="footer-links" to="/Stories"> Stories </Link>
             </div>
         </footer>
     );

--- a/vera-react-app/src/components/Navbar/Navbar.css
+++ b/vera-react-app/src/components/Navbar/Navbar.css
@@ -47,6 +47,15 @@ button:focus{
     border-top: #F1F4F7 solid 2px;
 }
 
+.navbar-links:hover{
+    text-decoration: underline;
+    color: #4A6E82;
+}
+
+.navbar-links:after{
+    color: #4A6E82;
+}
+
 @media only screen and (min-width: 768px) {
 
     .nav-main.navbar.navbar-expand-lg.navbar-light.bg-light{


### PR DESCRIPTION
Modified the styling for the respective components so that on hover/on click/ and after being clicked prior the color is maintained.

Additionally I added in an on hover underline that appears under the navigation options. 

Here is pictures of the navbar and footer on hover (color is the same on click and after):
<img width="997" alt="Screen Shot 2021-04-19 at 4 21 40 PM" src="https://user-images.githubusercontent.com/59515892/115315058-5fed8780-a12b-11eb-87b0-5ec736f1202e.png">
<img width="1003" alt="Screen Shot 2021-04-19 at 4 22 12 PM" src="https://user-images.githubusercontent.com/59515892/115315075-6845c280-a12b-11eb-9dd5-05db3ddb28d5.png">

I also changed the footer links to use the React Link, instead of being made of <a href>. 