### PR TITLE
Fixed button link color when hovering

### DIFF
--- a/vera-react-app/src/components/IndividualResourceTile/IndividualResourceTileExpanded.css
+++ b/vera-react-app/src/components/IndividualResourceTile/IndividualResourceTileExpanded.css
@@ -121,6 +121,12 @@ p.resource-tile-expanded-to-expect {
 
   width: fit-content;
   align-self: center;
+
+}
+
+.resource-tile-expanded-button:hover{
+  text-decoration: underline;
+  color: white;
 }
 
 /* Mobile specific setting */


### PR DESCRIPTION
On the individual resource page, when a user clicks on a tile, it expands to show some info and provides a "visit resource page" button. 

We fixed this issue by changing the text from highlighting blue to white and underlining to white when you hover over the button.

Modified the IndividualResourceTileExpanded css file.
<img width="1117" alt="Screen Shot 2023-02-01 at 4 02 03 PM" src="https://user-images.githubusercontent.com/59515892/216196370-7cf42ba9-e2b4-4c31-93be-13bbb18b35a7.png">

