### PR TITLE
Fixed Repeating Background Image in Banner Component

### DIFF
--- a/vera-react-app/src/components/Banner/Banner.js
+++ b/vera-react-app/src/components/Banner/Banner.js
@@ -6,7 +6,9 @@ function Banner(props) {
     return (
       <div
         className="img"
-        style={{ backgroundImage: `url(${props.imageUrl})` }}
+        style={{ backgroundImage: `url(${props.imageUrl})`,
+                 backgroundSize: "cover",
+                 backgroundRepeat: "no-repeat"}}
       >
         <h1 className="header0">{"."}</h1>
         <h1 className="header">{props.pageTitle}</h1>


### PR DESCRIPTION
Added two css fields for the background image in our banner component. These two attributes make the background image cover the dimensions of the component and also shuts down the option for the image to repeat. 