### PR TITLE
finished standardizing buttons

### DIFF
--- a/vera-react-app/src/components/StorySubmission/StorySubmission.css
+++ b/vera-react-app/src/components/StorySubmission/StorySubmission.css
@@ -112,11 +112,12 @@ div.ql-editor {
 .button-wrapper {
   display: flex;
   justify-content: center;
+  
 }
 
 .button {
 	padding: 16px 32px;
-	border-radius: 600px;
+	border-radius: 15px;
 	width: 204px;
   height: 64px;
   color: white;


### PR DESCRIPTION
Fairly straight forwards. All buttons now have a border-radius set to 15px. Only question is do we want the story submission drop downs to follow this styling? They have the same appearance of a button but have a more rounded edge.
<img width="1107" alt="Screenshot 2023-02-27 at 1 05 21 PM" src="https://user-images.githubusercontent.com/67762825/221686218-86ba57a9-eabc-4750-baef-9cc87fa689a5.png">
<img width="1089" alt="Screenshot 2023-02-27 at 1 05 28 PM" src="https://user-images.githubusercontent.com/67762825/221686259-1cc576ef-35f6-44d2-9eba-f4328a8c5216.png">
<img width="1062" alt="Screenshot 2023-02-27 at 1 05 34 PM" src="https://user-images.githubusercontent.com/67762825/221686361-2a9699c2-daf1-474d-a8ca-d060fc062b98.png">


