### PR TITLE
Remove border property from tile css

### DIFF
--- a/vera-react-app/src/components/Shared/Tile.js
+++ b/vera-react-app/src/components/Shared/Tile.js
@@ -12,7 +12,6 @@ export const Tile = styled.div`
     cursor: pointer;
     
     @media only screen and (max-width: 768px) {
-        border: 1px solid #4A6E82;
         width: 150px;
         height: 125px;
         background: #FFFFFF;


### PR DESCRIPTION
Remove border property from tile css according to Figma image. Drop shadow seems to have been already added. 