### PR TITLE
Story submission mobile size fix branch

### DIFF
--- a/vera-react-app/src/components/StorySubmission/StorySubmission.css
+++ b/vera-react-app/src/components/StorySubmission/StorySubmission.css
@@ -1,48 +1,26 @@
-
-
-.some_container {
+.input-outer-container {
     display: flex;
-    /* OG */
     margin: 3% 0px 1% 3%;
+}
 
-  }
-  
-  .left-box {
+.inner-container-box {
     flex: 1;
     display: flex;
     flex-direction: column;
-    /* From OG */
     margin: 0px 3% 0px 0px;
     width: 33%;
-  }
-  
-  .right-box {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    /* From OG */
-    margin: 0px 3% 0px 0px;
-    width: 33%;
-  }
-  
-  .left-element {
-    flex: 1;
-  }
-  
-  @media (max-width: 767px) {
-    .some_container {
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      
+}
+
+@media (max-width: 767px) {
+    .input-outer-container {
+        flex-direction: column;
     }
-  
-    .left-box, .right-box {
-      flex: none;
-      width: 90%;
-      
+
+    .inner-container-box {
+        flex: none;
+        width: 97%;
     }
-  }
+}
 
 #editor-container {
   height: 375px;
@@ -57,16 +35,6 @@
   background-color: white;
   filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
 }
-
-/* .row1{
-  display: flex;
-  flex-direction:column;
-  margin: 0px 3% 0px 0px;
-  width: 33%;
-  border: 2px dotted red;
-
-
-} */
 
 .inputs {
   display: flex;

--- a/vera-react-app/src/components/StorySubmission/StorySubmission.js
+++ b/vera-react-app/src/components/StorySubmission/StorySubmission.js
@@ -57,38 +57,21 @@ function StorySubmission() {
   
   return (
       <div>
-          <div class="some_container">
-              <div class="left-box">
-                  <div class="left-element">              <DropDownForm className="left-element" fieldTitle="Year" myoptions={yearList} handleChange={handleYearChange} />
-                  </div>
-                  <div class="left-element">                      <DropDownForm className="left-element" fieldTitle="College" myoptions={collegeList} handleChange={handleCollegeChange} />
-                  </div>
-              </div>
-              <div class="right-box"><DropDownOptionalForm className="left-element" fieldTitle="Major (optional)" myoptions={majorList} handleChange={handleMajorChange}/></div>
-          </div>
-
-
           <div className="background">
-            <form className="story-submission-box" onSubmit={verifySubmission}>
-              {/* <div className="story-submission-box"> */}
-                {/* <div className='some_container'>
-                  <div className="left-box">
-                      <DropDownForm className="left-element" fieldTitle="Year" myoptions={yearList} handleChange={handleYearChange}/> 
-                      <DropDownForm className="left-element" fieldTitle="College" myoptions={collegeList} handleChange={handleCollegeChange}/>
-                  </div>
-                  <div className="right-box" id="option">
-                      <DropDownOptionalForm className="left-element" fieldTitle="Major (optional)" myoptions={majorList} handleChange={handleMajorChange}/>
-                  </div>
-                </div> */}
-                  <div class="some_container">
-                      <div class="left-box">
-                          <div class="left-element"> <DropDownForm className="left-element" fieldTitle="Year" myoptions={yearList} handleChange={handleYearChange} />
+              <form className="story-submission-box" onSubmit={verifySubmission}>
+                  <div class="input-outer-container">
+                      <div class="inner-container-box">
+                          <div >
+                              <DropDownForm fieldTitle="Year" myoptions={yearList} handleChange={handleYearChange} />
                           </div>
-                          <div class="left-element"> <DropDownForm className="left-element" fieldTitle="College" myoptions={collegeList} handleChange={handleCollegeChange} />
+                          <div >
+                              <DropDownForm fieldTitle="College" myoptions={collegeList} handleChange={handleCollegeChange} />
                           </div>
                       </div>
-              <div class="right-box"><DropDownOptionalForm className="left-element" fieldTitle="Major (optional)" myoptions={majorList} handleChange={handleMajorChange}/></div>
-          </div>
+                      <div class="inner-container-box">
+                          <DropDownOptionalForm fieldTitle="Major (optional)" myoptions={majorList} handleChange={handleMajorChange} />
+                      </div>
+                  </div>
                 <div className="description-box"> 
                   <div className="title-text">
                     Short Description


### PR DESCRIPTION
* Fixed issue of drop down fields in submissions page being to small for mobile by moving fields to a new line and expanding them when they reach a min width
* Created a outer horizontal flex box that is divided into two vertical flex box columns
* When the horizontal flex box reaches a min width, it changes to a vertical flexbox and allows the three drop down options to be on its own line and fully expand. 

Regular vs Mobile view: 
![chrome_Za9adiZe4x](https://github.com/CS-Social-Good-CalPoly/Vera2.0/assets/73367549/bd81c3a9-6ebd-4588-86a2-30debcbc4f1b)
![chrome_7LuWQv6Lpc](https://github.com/CS-Social-Good-CalPoly/Vera2.0/assets/73367549/937226e7-82a6-49ec-8aa6-af4512b617d5)
