### PR TITLE
fixed longer titles

### DIFF
--- a/vera-react-app/src/components/Shared/Tile.js
+++ b/vera-react-app/src/components/Shared/Tile.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const Tile = styled.div`
   position: relative;
   width: 280px;
-  height: 280px;
+  height: 290px;
   background: #FFFFFF;
   box-shadow: 4px 4px 15px rgba(114, 141, 149, 0.15);
   border-radius: 30px;
@@ -65,13 +65,23 @@ export const TileTitle = styled.h1`
     text-transform: uppercase;
     color: black;
     overflow: hidden;
-    height: 30px;
+    display: -webkit-box;
+    -webkit-line-clamp: 3; 
+    -webkit-box-orient: vertical;
+    line-height: 1em;
+    max-height: 3em; 
+    margin-bottom: 15px;
 
   @media only screen and (max-width: 768px) {
     padding: 0 6px;
     font-weight: 600;
     font-size: 10px;
     line-height: 12px;
-    height: 13px;
+    display: -webkit-box;
+    -webkit-line-clamp: 2; 
+    -webkit-box-orient: vertical;
+    line-height: 1em;
+    max-height: 2em; 
+    margin-bottom: 10px;
   }
 `;


### PR DESCRIPTION
Increased the tile height from 280px to 290px so the tile and text would fit better in the text.

removed height from tile title and then used webkit-box to limit to 3 lines on normal screen and 2 lines on mobile. Added bottom margin to have better spacing between title and text.

PC:
![pc1](https://github.com/CS-Social-Good-CalPoly/Vera2.0/assets/97060375/6038deac-af4e-46ae-953a-781217a944dc)


Mobile
![phone1](https://github.com/CS-Social-Good-CalPoly/Vera2.0/assets/97060375/a1a18fc3-c04f-40e4-9e5e-22591b37910e)
