### PR TITLE
 Title Prompt Repopulate Fix 

### DIFF
--- a/vera-react-app/src/components/StorySubmission/StorySubmission.js
+++ b/vera-react-app/src/components/StorySubmission/StorySubmission.js
@@ -10,7 +10,7 @@ function StorySubmission() {
   const [college, setCollege] = useState("")
   const [major, setMajor] = useState("")
   const [quillValue, setQuillValue] = useState('');
-  const [title, setTitleValue] = useState("Enter title");
+  const [title, setTitleValue] = useState("");
 
   const values = {
     "Year" : year,
@@ -19,22 +19,10 @@ function StorySubmission() {
     "Description" : quillValue
   }
 
-  const fakeInput = "Enter title"
-
   const handleTitleKeyPress = (e) => {
-    if(e.key === "\t" && e.value === ""){
-      e.preventDefault()
-      setTitleValue(fakeInput)
-    }
-    setTitleValue(e.value)
+    setTitleValue(e.target.value)
   }
   
-  const handleTitleClick = (e) => {
-    if (title === "Enter title") {
-      setTitleValue('');
-    }
-  }
-
   const handleYearChange = (e) => {
     setYear(e);
   }
@@ -48,7 +36,7 @@ function StorySubmission() {
   }
 
   const handleTitleChange = (e) => {
-    setTitleValue(e.value);
+    setTitleValue(e.target.value);
   }
 
 
@@ -97,10 +85,9 @@ function StorySubmission() {
                     {/* figure out way to temporary  text when no text typed yet - ie 3 states state 1 'enter text ' once u click text goes away, but state stays, then once starts typing- final state*/}
                     <input
                       className='inputBar'
+                      placeholder="Enter title"
                       type="text"
                       value={title}
-                      onClick={handleTitleClick}
-                      onFocus={handleTitleClick}
                       onKeyPress={handleTitleKeyPress}
                       onChange={handleTitleChange}
                     />


### PR DESCRIPTION
* Added a placeholder attribute to the input box 
* Placeholder attribute displays text when input box is empty, disappears when text is inputted, and shows placeholder text again if input text is removed
* I deleted code that seemed like they were unused / used for the old way of handling input to the title
* I changed e.value to e.target.value to correctly store the title input in the state. 

![chrome_146z7te8qk](https://github.com/CS-Social-Good-CalPoly/Vera2.0/assets/73367549/3722a6d5-6739-4cb1-a202-183edd24d984)
![chrome_zamL6DvCH8](https://github.com/CS-Social-Good-CalPoly/Vera2.0/assets/73367549/e3926fa1-2698-47fc-b91e-b830d100a4f0)

