### PR TITLE
Make relevant resources display use db data

### DIFF
--- a/vera-react-app/src/components/StoryPopUp/StoryPopUp.js
+++ b/vera-react-app/src/components/StoryPopUp/StoryPopUp.js
@@ -118,6 +118,7 @@ const Text = styled(Card.Text)`
 function StoryPopUp(props) {
     const [size, setSize] = useState(false);
     const relevantResourceData = mockRelevantResourceData;
+    const [subResource, setSubResource] = useState([]);
 
     function change() {
         setSize(true);
@@ -138,6 +139,19 @@ function StoryPopUp(props) {
             {setindividualStory(data);})
           .catch(error => console.error(error));
       }, []);
+
+
+    useEffect(() => {
+        fetch('http://localhost:3001/resources/subrsrcs')
+            .then(response => response.json())
+            .then(data => {
+                if (data.length > 0) {
+                    const subList = data.slice(0, 3)
+                    setSubResource(subList);
+                }
+            })
+            .catch(error => console.error(error));
+    }, []);
 
     const currentStory = individualStory[0];
 
@@ -173,7 +187,7 @@ function StoryPopUp(props) {
                 <ResourcePageTileGroup
                     id="RelevantResources"
                     title="Relevant Resources"
-                    resources={relevantResourceData}
+                    resources={subResource}
                 />
             </PopupResources>
         </test>

--- a/vera-react-app/src/components/StoryPopUp/mockRelevantData.json
+++ b/vera-react-app/src/components/StoryPopUp/mockRelevantData.json
@@ -1,9 +1,9 @@
 [
     {
         "id": "1",
-        "title": "General Stress",
-        "description": "Stress is a feeling of emotional or physical tension. It can come from any event or thought that makes you feel frustrated, angry.",
-        "imageUrl": "https://images.unsplash.com/photo-1503551723145-6c040742065b-v2?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2070&q=80"
+        "Title": "General Stress",
+        "LongDescription": "Stress is a feeling of emotional or physical tension. It can come from any event or thought that makes you feel frustrated, angry.",
+        "ImageURL": "https://images.unsplash.com/photo-1503551723145-6c040742065b-v2?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2070&q=80"
     }, 
     {
         "id": "2",


### PR DESCRIPTION
* I changed the relevant resources tab to display resources from the database instead of hardcoded resources 
* I am fetching the resources from the route resources/subrsrcs
* This route returns many resources so I only display the first 3 
![image](https://github.com/CS-Social-Good-CalPoly/Vera2.0/assets/73367549/92ff27b4-27c9-4297-9232-7e2f30805bd9)
