### PR TITLE
Individual Resource Tile Ellipses #167

### DIFF
--- a/vera-react-app/src/components/IndividualResourceTile/IndividualResouceTile.js
+++ b/vera-react-app/src/components/IndividualResourceTile/IndividualResouceTile.js
@@ -1,8 +1,31 @@
-import React, { useState } from "react";
+import React, { useState, useEffect} from "react";
 import IndividualResourceTileCollapsed from "./IndividualResourceTileCollapsed";
 import IndividualResourceTileExpanded from "./IndividualResourceTileExpanded";
 
+import TruncateText from "./TruncateText";
+
 function IndividualResourceTile(props) {
+    const [maxContainerWidthPx, setMaxContainerWidthPx] = useState(0)
+
+    useEffect(() => {
+        let width = 0
+        const handleResize = () => {
+            width = window.innerWidth;
+            if (width < 0) {
+                setMaxContainerWidthPx(0);
+            } else if (width > 0 && width < 769) {
+                setMaxContainerWidthPx(46);
+            } else if (width >= 769 && width < 2000) {
+                setMaxContainerWidthPx(90);
+            } else {
+                setMaxContainerWidthPx(2000);
+            }
+        };
+
+        window.addEventListener('resize', handleResize);
+        handleResize();
+        return () => window.removeEventListener('resize', handleResize);
+    });
 
     const [expanded, setExpanded] = useState(false);
 
@@ -26,7 +49,8 @@ function IndividualResourceTile(props) {
     ) : (
         <IndividualResourceTileCollapsed
             title={props.title}
-            infoText={props.description}
+            infoText=
+            {<TruncateText text={props.description} factor={3.1} maxLines={4} containerWidth={maxContainerWidthPx} />}
             imageUrl={props.imgUrl}
             handleChange={handleChange}
         />

--- a/vera-react-app/src/components/IndividualResourceTile/IndividualResourceTileCollapsed.js
+++ b/vera-react-app/src/components/IndividualResourceTile/IndividualResourceTileCollapsed.js
@@ -18,16 +18,25 @@ const InfoText = styled.p`
   margin: 0px;
   align-self: center;
 
+  // @media only screen and (max-width: 768px) {
+  //   position: relative;
+  //   margin: 0px;
+  //   width: 90%;
+  //   height: 30%;
+  //   font-size: 12px;
+  //   line-height: 15px;
+  //   padding: 0 6px 0px;
+  //   overflow: hidden;
+  //   align-self: center;
+  // }
   @media only screen and (max-width: 768px) {
-    position: relative;
-    margin: 0px;
-    width: 90%;
-    height: 30%;
-    font-size: 12px;
-    line-height: 15px;
-    padding: 0 6px 0px;
+    font-size: 10px;
+    line-height: 12px;
+    padding-left: 6px;
+    padding-right: 14px;
+    padding-top: 4px;
+    height: 40px;
     overflow: hidden;
-    align-self: center;
   }
 `;
 

--- a/vera-react-app/src/components/IndividualResourceTile/TruncateText.jsx
+++ b/vera-react-app/src/components/IndividualResourceTile/TruncateText.jsx
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from "react"
+
+const TruncateText = ({ text, factor, maxLines, containerWidth }) => {
+    const [truncatedText, setTruncatedText] = useState("")
+
+    useEffect(() => {
+        setTruncatedText(truncateText(text, factor, maxLines, containerWidth))
+    }, [text, factor, maxLines, containerWidth])
+
+    const truncateText = (text, factor, maxLines, containerWidth) => {
+        const maxLineWidth = containerWidth / factor // Factor is kind of like average char width
+        const words = text.split(" ")
+
+        let lineCount = 1
+        let charsCount = 0
+        let truncated = ""
+
+        for (const word of words) {
+            const wordLength = word.length
+
+            if (charsCount + wordLength + 1 > maxLineWidth * lineCount) {
+                lineCount += 1
+
+                if (lineCount > maxLines) {
+                    truncated = truncated.trim() + "..."
+                    break
+                }
+
+            }
+            
+            if (truncated.length > 0) {
+                truncated += " "
+            }
+
+            truncated += word
+            charsCount += wordLength + 1
+        }
+
+        return truncated
+    }
+
+    return truncatedText
+        
+   
+}
+
+export default TruncateText


### PR DESCRIPTION
Both the issues of text overflowing in the desktop and mobile versions have been fixed. 

For the desktop version, I implemented the solution used for the same problem in [#167](https://github.com/CS-Social-Good-CalPoly/Vera2.0/issues/167)

For the mobile version, I matched the CSS to the one used in the resource page tile.

![image](https://github.com/CS-Social-Good-CalPoly/Vera2.0/assets/63116527/9c3a3905-85cb-48b2-b9f1-09c146e32f6c)
![image](https://github.com/CS-Social-Good-CalPoly/Vera2.0/assets/63116527/4033d307-5aee-431d-938b-8590b1c81ca3)
