### PR TITLE
Closes #205 - Remove Hardcoded URL and Port Values

### DIFF
--- a/frontend/src/components/StoryPopUp/StoryPopUp.js
+++ b/frontend/src/components/StoryPopUp/StoryPopUp.js
@@ -4,6 +4,7 @@ import { ResourcePageTileGroup, Banner } from '../components.js'
 import styled from 'styled-components'
 import mockRelevantResourceData from './mockRelevantData.json'
 import moment from 'moment'
+import URL_PATH from '../../links'
 
 const Header = styled.div`
     font-size: 32px;
@@ -133,7 +134,10 @@ function StoryPopUp(props) {
     const [individualStory, setindividualStory] = useState([])
 
     useEffect(() => {
-        fetch('http://localhost:3001/stories/individualstory')
+        // URL_PATH imported from frontend/src/links.js
+        // combined with subdirectory to make the full URL
+        const subdirectory = '/stories/individualstory'
+        fetch(URL_PATH + subdirectory)
             .then((response) => response.json())
             .then((data) => {
                 setindividualStory(data)
@@ -142,7 +146,10 @@ function StoryPopUp(props) {
     }, [])
 
     useEffect(() => {
-        fetch('http://localhost:3001/resources/subrsrcs')
+        // URL_PATH imported from frontend/src/links.js
+        // combined with subdirectory to make the full URL
+        const subdirectory = '/resources/subrsrcs'
+        fetch(URL_PATH + subdirectory)
             .then((response) => response.json())
             .then((data) => {
                 if (data.length > 0) {

--- a/frontend/src/components/StorySubmission/StorySubmission.js
+++ b/frontend/src/components/StorySubmission/StorySubmission.js
@@ -3,6 +3,7 @@ import { DropDownForm, DropDownOptionalForm } from '../components'
 import ReactQuill from 'react-quill'
 import 'react-quill/dist/quill.snow.css'
 import './StorySubmission.css'
+import URL_PATH from '../../links'
 
 function StorySubmission() {
     const [year, setYear] = useState('')
@@ -88,16 +89,16 @@ function StorySubmission() {
             console.log(data)
 
             try {
-                const response = fetch(
-                    'http://localhost:3001/stories/storysubmission',
-                    {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                        },
-                        body: JSON.stringify(data),
+                // URL_PATH imported from frontend/src/links.js
+                // combined with subdirectory to make the full URL
+                const subdirectory = '/stories/storysubmission'
+                const response = fetch(URL_PATH + subdirectory, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
                     },
-                )
+                    body: JSON.stringify(data),
+                })
 
                 const responseData = response.json()
                 console.log('Server response:', responseData)

--- a/frontend/src/links.js
+++ b/frontend/src/links.js
@@ -1,6 +1,6 @@
 const PROTOCOL = 'http'
 const HOSTNAME = 'localhost'
-export const PORT = '3001'
+const PORT = '3001'
 const URL_PATH = PROTOCOL + '://' + HOSTNAME + ':' + PORT
 
 export default URL_PATH

--- a/frontend/src/links.js
+++ b/frontend/src/links.js
@@ -1,0 +1,6 @@
+const PROTOCOL = 'http'
+const HOSTNAME = 'localhost'
+export const PORT = '3001'
+const URL_PATH = PROTOCOL + '://' + HOSTNAME + ':' + PORT
+
+export default URL_PATH

--- a/frontend/src/pages/HomePage/HomePage.js
+++ b/frontend/src/pages/HomePage/HomePage.js
@@ -7,6 +7,8 @@ import {
     CategoryButtonGroup,
     ResourcePageTileGroup,
 } from '../../components/components'
+import '../../links'
+import URL_PATH from '../../links'
 
 function HomePage() {
     // Hook to keep track of the categories to be loaded from the database.
@@ -25,7 +27,10 @@ function HomePage() {
     // This hook will execute before the other one.
     // It fetches the subrsrcs data and stores it into subresourceDict for later use.
     useEffect(() => {
-        fetch('http://localhost:3001/resources/subrsrcs')
+        // URL_PATH imported from frontend/src/links.js
+        // combined with subdirectory to make the full URL
+        const subdirectory = '/resources/subrsrcs'
+        fetch(URL_PATH + subdirectory)
             .then((response) => response.json())
             .then((json) => {
                 // Create a dictionary using subresource id as the key
@@ -42,7 +47,10 @@ function HomePage() {
     // Hook which executes fetch (GET) to the database and is only
     // run upon the very first render of the website.
     useEffect(() => {
-        fetch('http://localhost:3001/resources/generalrsrcscat')
+        // URL_PATH imported from frontend/src/links.js
+        // combined with subdirectory to make the full URL
+        const subdirectory = '/resources/generalrsrcscat'
+        fetch(URL_PATH + subdirectory)
             .then((response) => response.json())
             .then((json) => {
                 let tempArray = []

--- a/frontend/src/pages/IndividualResourcePage/IndividualResourcePage.js
+++ b/frontend/src/pages/IndividualResourcePage/IndividualResourcePage.js
@@ -6,6 +6,7 @@ import {
     TextBlock,
 } from '../../components/components'
 import { useLocation } from 'react-router-dom'
+import URL_PATH from '../../links'
 
 function IndividualResourcePage() {
     const location = useLocation()
@@ -19,9 +20,10 @@ function IndividualResourcePage() {
     const [resourceList, setResourceList] = useState([])
 
     useEffect(() => {
-        fetch(
-            `http://localhost:3001/resources/individualResources?${individualIDsQueryParam}`,
-        )
+        // URL_PATH imported from frontend/src/links.js
+        // combined with subdirectory to make the full URL
+        const subdirectory = `/resources/individualResources?${individualIDsQueryParam}`
+        fetch(URL_PATH + subdirectory)
             .then((response) => response.json())
             .then((json) => {
                 let tempDict = {}

--- a/frontend/src/pages/StoriesPage/StoriesPage.js
+++ b/frontend/src/pages/StoriesPage/StoriesPage.js
@@ -4,6 +4,7 @@ import {
     CategoryButtonGroup,
     StoryTileGroup,
 } from '../../components/components'
+import URL_PATH from '../../links'
 
 function StoriesPage() {
     const [stories, setStories] = useState([])
@@ -11,7 +12,10 @@ function StoriesPage() {
     const [categorNames, setCategorNames] = useState([])
 
     useEffect(() => {
-        fetch('http://localhost:3001/stories/generalstorycat')
+        // URL_PATH imported from frontend/src/links.js
+        // combined with subdirectory to make the full URL
+        const subdirectory = '/stories/generalstorycat'
+        fetch(URL_PATH + subdirectory)
             .then((response) => response.json())
             .then((json) => {
                 let tempArray = []
@@ -28,7 +32,10 @@ function StoriesPage() {
     }, [])
 
     useEffect(() => {
-        fetch('http://localhost:3001/stories/individualstory')
+        // URL_PATH imported from frontend/src/links.js
+        // combined with subdirectory to make the full URL
+        const subdirectory = '/stories/individualstory'
+        fetch(URL_PATH + subdirectory)
             .then((response) => response.json())
             .then((json) => {
                 // Create a dictionary using subresource id as the key


### PR DESCRIPTION
Closes #205 

I created a links.js file in the frontend/src directory to hold the protocol (http), hostname (localhost), and port number (3001). These combine to create the URL path (http://localhost:3001), which is exported as URL_PATH.

In the StoryPopUp.js, StorySubmission.js, StoriesPage.js HomePage.js, and IndividualResourcePage.js, they import URL_PATH from links.js, which is used to create the full URL within the fetches. I also created a const subdirectory which holds the unique remainder of the URL for each of the fetches. Thus, where 'http://localhost:3001/subDir1/subDir2' used to be is now URL_PATH + subdirectory. This makes adjusting the URL on the frontend much easier since only the links.js file needs to be adjusted.