### PR TITLE
Fix buggy Story Title backend

### DIFF
--- a/frontend/src/components/StorySubmission/StorySubmission.js
+++ b/frontend/src/components/StorySubmission/StorySubmission.js
@@ -16,6 +16,7 @@ function StorySubmission() {
         College: college,
         Major: major,
         Description: quillValue,
+        Title: title
     }
 
     const handleTitleKeyPress = (e) => {
@@ -77,7 +78,7 @@ function StorySubmission() {
             alert('Thank you for your submission!')
 
             const data = {
-                Title: 'My Story Title',
+                Title: values.Title,
                 ParagraphText: values.Description,
                 Date: new Date(),
                 StudentMajor: values.Major,


### PR DESCRIPTION
Before, the Story title when submitting would not update to the backend, and now it updates the database title from the story submission as you can see in MongoDB. The issue was that the placeholder text, "My Story Title" was hardcoded into the 'handlePost()' function. I changed it to use 'values.Title', and I added the Title field to the 'const values' so that it could be accessed. 