### PR TITLE
#242 Add Admin Approval Fields To Schema

### DIFF
--- a/backend/models/IndividualStories.js
+++ b/backend/models/IndividualStories.js
@@ -16,6 +16,8 @@ const StorySchema = new Schema({
     StudentCollege: String,
     StudentYear: String,
     GeneralCategory: String,
+    Status: { type: String, default: 'review' },
+    RejectionReasonList: { type: [String], default: [] },
 })
 
 module.exports = model('story', StorySchema, 'story')


### PR DESCRIPTION
Closes #242 

I added the "Status" and "RejectionReasonList" fields to the schema in IndividualStories.js. "Status" is a string with "review" as the default value, and "RejectionReasonList" is an array of strings with an empty array as the default.

Attached is a screenshot of the database, highlighting the new fields and their proper default values.
![new schemas](https://github.com/CS-Social-Good-CalPoly/Vera/assets/113927918/c9387c8f-9ea7-49c8-8fcb-71630ee50dfb)
