### PR TITLE
Get categories from backend

### DIFF
--- a/frontend/src/components/StorySubmission/StorySubmission.js
+++ b/frontend/src/components/StorySubmission/StorySubmission.js
@@ -11,11 +11,12 @@ function StorySubmission() {
     const [year, setYear] = useState('')
     const [college, setCollege] = useState('')
     const [major, setMajor] = useState('')
+    const [category, setCategory] = useState('')
     const [quillValue, setQuillValue] = useState('')
     const [title, setTitleValue] = useState('')
     const [collegeList, setCollegeList] = useState([])
     const [majorList, setMajorList] = useState([])
-    const [category, setCategory] = useState([])
+    const [categoryList, setCategoryList] = useState([])
 
     const values = {
         Year: year,
@@ -88,6 +89,17 @@ function StorySubmission() {
             .catch((err) => console.error(err))
     }, [])
 
+    useEffect(() => {
+        axios
+            .get('http://localhost:3001/stories/generalstorycat')
+            .then((res) => {
+                const category_lst = res.data.map(item => item.Title);
+                console.log(category_lst)
+                setCategoryList(category_lst)
+            })
+            .catch((err) => console.error(err))
+    }, [])
+
     const yearList = [
         '1st Year',
         '2nd Year',
@@ -95,10 +107,7 @@ function StorySubmission() {
         '4th Year',
         '5th+ Year',
     ]
-    const categoryList = [
-        'School',
-        'Family',
-    ]
+
 
     function verifySubmission(e) {
         // if an option is selected, the value is stored as 1 at the moment


### PR DESCRIPTION
Previously, the category dropdown options in StorySubmission.js were hard coded as an array. I created a get request from the existing API endpoint /stories/generalstorycat. The two options are the same (School and Family) but now they are coming from the backend and can be updated from there.
<img width="1105" alt="Screenshot 2024-02-12 at 7 46 54 PM" src="https://github.com/CS-Social-Good-CalPoly/Vera/assets/55379287/bda7dad0-4a54-435c-a0ec-abf6d5e2e72c">
