### PR TITLE
#204 - College dropdown not re-rendering when state changes

### DIFF
--- a/frontend/src/components/StorySubmission/StorySubmission.js
+++ b/frontend/src/components/StorySubmission/StorySubmission.js
@@ -15,6 +15,7 @@ function StorySubmission() {
     const [quillValue, setQuillValue] = useState('')
     const [title, setTitleValue] = useState('')
     const [collegeDict, setCollegeDict] = useState({})
+    const [categoryList, setCategoryList] = useState([])
 
     const values = {
         Year: year,

--- a/frontend/src/components/StorySubmission/StorySubmission.js
+++ b/frontend/src/components/StorySubmission/StorySubmission.js
@@ -78,9 +78,10 @@ function StorySubmission() {
                             ) {
                                 // Create key/value pair; keys = majors, values = colleges
                                 // Note: keys are unique, colleges duplicate
-                                college_dict[major_name] = college_name
+                                college_dict[major_name.replace(' Major', '')] =
+                                    college_name
                                 console.log(
-                                    major_name +
+                                    major_name.replace(' Major', '') +
                                         ': ' +
                                         college_dict[major_name],
                                 )

--- a/frontend/src/components/StorySubmission/StorySubmission.js
+++ b/frontend/src/components/StorySubmission/StorySubmission.js
@@ -172,7 +172,7 @@ function StorySubmission() {
                             </div>
                             <div>
                                 <DropDownForm
-                                    fieldTitle="College"
+                                    fieldTitle={college ? college : 'College'}
                                     myoptions={[
                                         ...new Set(Object.values(collegeDict)),
                                     ]}

--- a/frontend/src/components/StorySubmission/StorySubmission.js
+++ b/frontend/src/components/StorySubmission/StorySubmission.js
@@ -78,10 +78,9 @@ function StorySubmission() {
                             ) {
                                 // Create key/value pair; keys = majors, values = colleges
                                 // Note: keys are unique, colleges duplicate
-                                college_dict[major_name.replace(' Major', '')] =
-                                    college_name
+                                college_dict[major_name] = college_name
                                 console.log(
-                                    major_name.replace(' Major', '') +
+                                    major_name +
                                         ': ' +
                                         college_dict[major_name],
                                 )

--- a/frontend/src/components/StorySubmission/StorySubmission.js
+++ b/frontend/src/components/StorySubmission/StorySubmission.js
@@ -14,7 +14,6 @@ function StorySubmission() {
     const [category, setCategory] = useState('')
     const [quillValue, setQuillValue] = useState('')
     const [title, setTitleValue] = useState('')
-    const [category, setCategory] = useState([])
     const [collegeDict, setCollegeDict] = useState({})
 
     const values = {


### PR DESCRIPTION
Closes #204 

I changed the existing college and major arrays to be a dictionary of major-college pairs with the majors as keys and colleges as values. In my implementation, there are duplicate colleges, but these are easily removed for the college dropdown by extracting the college values from the Object, using the array of values to make a Set, and casting the Set back into an array. This seemed more elegant than using colleges as keys and creating an array/LinkedList for the major within the same college.

Then, I adjusted the handler for the major dropdown `handleMajorChange` to include `setCollege(collegeDict[e])`, which sets the `college` state to the corresponding college for the given major. However, the college dropdown is not re-rendering on the website. Instead, it still displays "College". To ensure that the college is changing states correctly, I created a useEffect with the `college` state as the dependency. So, whenever the `college` state changes, it `console.log`'s the `college`. Inspecting the console from the website reveals the state with the correct college.

It turns out that the form is actually re-rendering correctly, but it's `fieldTitle` attribute was always set to "College". Using a ternary expression with the college state easily fixed this issue. The college `DropDownForm` now correctly auto-fills with the corresponding college after a major is selected.