### PR TITLE
#258 - Remove 'Major' Substring From Major Entries

### DIFF
--- a/frontend/src/components/StorySubmission/StorySubmission.js
+++ b/frontend/src/components/StorySubmission/StorySubmission.js
@@ -78,12 +78,9 @@ function StorySubmission() {
                             ) {
                                 // Create key/value pair; keys = majors, values = colleges
                                 // Note: keys are unique, colleges duplicate
-                                college_dict[major_name] = college_name
-                                console.log(
-                                    major_name +
-                                        ': ' +
-                                        college_dict[major_name],
-                                )
+                                college_dict[
+                                    major_name.replace('Major', '').trim()
+                                ] = college_name
                             }
                         })
                     }


### PR DESCRIPTION
Closes #258 

Added a `.replace("Major", "")` and `.trim()` to `major_name` when creating a new major-college entry in the `collegeDict` object. The line is now: `college_dict[major_name.replace('Major', '').trim()] = college_name` where `major_name` and `college_name` are both web scraped.

The form now allows users to select a major which does not include "Major" in the title. Upon selecting a major, the college field is automatically populated accordingly.