### PR TITLE
#273 - Add Prop Passing for All Pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -36,7 +36,9 @@ function App() {
                     <Route
                         exact
                         path="/individualResource"
-                        component={() => <IndividualResourcePage />}
+                        component={() => (
+                            <IndividualResourcePage setActiveLink={setActiveLink} />
+                        )}
                     />
                     <Route
                         exact
@@ -48,7 +50,9 @@ function App() {
                     <Route
                         exact
                         path="/individualStory"
-                        component={() => <IndividualStoryPage />}
+                        component={() => (
+                            <IndividualStoryPage setActiveLink={setActiveLink} />
+                        )}
                     />
                     <Route
                         exact
@@ -62,7 +66,9 @@ function App() {
                     <Route
                         exact
                         path="/AdminPages"
-                        component={() => <AdminPages />}
+                        component={() => (
+                            <AdminPages setActiveLink={setActiveLink} /> 
+                        )}
                     />
                 </Switch>
             </div>

--- a/frontend/src/pages/AdminPage/AdminPages.js
+++ b/frontend/src/pages/AdminPage/AdminPages.js
@@ -6,7 +6,7 @@ import {
 } from '../../components/components'
 import URL_PATH from '../../links'
 
-function AdminPages() {
+function AdminPages({ setActiveLink }) {
     const [stories, setStories] = useState([])
     // const [nameToID, setNameToID] = useState({})
     // const [categorNames, setCategorNames] = useState([])
@@ -17,7 +17,7 @@ function AdminPages() {
         fetch(URL_PATH + subdirectory)
             .then((response) => response.json())
             .then((json) => {
-                console.log(json);
+                console.log(json)
                 let tempArray = json.map((story) => ({
                     _id: story._id,
                     Title: story.Title,
@@ -27,6 +27,10 @@ function AdminPages() {
                 setStories(tempArray)
             })
             .catch((error) => console.error(error))
+    }, [])
+
+    useEffect(() => {
+        setActiveLink('/AdminPages')
     }, [])
 
     const handleFilter = (discipline) => {

--- a/frontend/src/pages/IndividualResourcePage/IndividualResourcePage.js
+++ b/frontend/src/pages/IndividualResourcePage/IndividualResourcePage.js
@@ -8,7 +8,7 @@ import {
 import { useLocation } from 'react-router-dom'
 import URL_PATH from '../../links'
 
-function IndividualResourcePage() {
+function IndividualResourcePage({ setActiveLink }) {
     const location = useLocation()
     const { individualIDs, title, description, imageUrl } = location.state || {}
 
@@ -40,6 +40,10 @@ function IndividualResourcePage() {
                 window.scrollTo(0, 0)
             })
             .catch((error) => console.error(error))
+    }, [])
+
+    useEffect(() => {
+        setActiveLink('/IndividualResource')
     }, [])
 
     return (

--- a/frontend/src/pages/IndividualResourcePage/IndividualResourcePage.js
+++ b/frontend/src/pages/IndividualResourcePage/IndividualResourcePage.js
@@ -43,7 +43,7 @@ function IndividualResourcePage({ setActiveLink }) {
     }, [])
 
     useEffect(() => {
-        setActiveLink('/IndividualResource')
+        setActiveLink('/Resources')
     }, [])
 
     return (

--- a/frontend/src/pages/IndividualStoryPage/IndividualStoryPage.js
+++ b/frontend/src/pages/IndividualStoryPage/IndividualStoryPage.js
@@ -1,12 +1,16 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { StoryPopUp } from '../../components/components'
 import { useLocation } from 'react-router-dom'
 
-function IndividualStoryPage() {
+function IndividualStoryPage({ setActiveLink }) {
     const location = useLocation()
     let id = location.state.storyID
     // console.log('hi')
     // console.log(id)
+
+    useEffect(() => {
+        setActiveLink('/IndividualStory')
+    }, [])
 
     return (
         <div>

--- a/frontend/src/pages/IndividualStoryPage/IndividualStoryPage.js
+++ b/frontend/src/pages/IndividualStoryPage/IndividualStoryPage.js
@@ -9,7 +9,7 @@ function IndividualStoryPage({ setActiveLink }) {
     // console.log(id)
 
     useEffect(() => {
-        setActiveLink('/IndividualStory')
+        setActiveLink('/Stories')
     }, [])
 
     return (

--- a/frontend/src/pages/IndividualStoryPage/IndividualStoryPage.js
+++ b/frontend/src/pages/IndividualStoryPage/IndividualStoryPage.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import { StoryPopUp } from '../../components/components'
 import { useParams } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 
 function IndividualStoryPage({ setActiveLink }) {
     const location = useLocation()


### PR DESCRIPTION
Closes #273 

Added the `setActiveLink` prop to the `AdminPages`, `IndividualResourcesPage`, and `IndividualStoryPage` following the formatting and style described in PR #270. The navbar now properly underlines the appropriate page based on which page the user is on. At the moment, `AdminPages`, `IndividualResourcesPage`, and `IndividualStoryPage` do not get underlined as they are not listed on the navbar.