### PR TITLE
Extract story ID from pathname

### DIFF
--- a/frontend/src/pages/IndividualStoryPage/IndividualStoryPage.js
+++ b/frontend/src/pages/IndividualStoryPage/IndividualStoryPage.js
@@ -5,9 +5,8 @@ import { useLocation } from 'react-router-dom'
 
 function IndividualStoryPage({ setActiveLink }) {
     const location = useLocation()
-    let id = location.state.storyID
-    // console.log('hi')
-    // console.log(id)
+    const pathSegments = location.pathname.split('/')
+    const id = pathSegments[pathSegments.length - 1]
 
     useEffect(() => {
         setActiveLink('/Stories')


### PR DESCRIPTION
The location object from useLocation() has changed for some reason and the id can no longer be retrieved through location.state.storyID, so instead retrieve  the id through pathname.

Current useLocation object example 
![Screenshot 2024-05-11 at 5 08 12 PM](https://github.com/CS-Social-Good-CalPoly/Vera/assets/73367549/745cd0b7-d5cc-4b25-950e-964c751cfc6c)
