### PR TITLE
Add filtering and tags to the Story page

### DIFF
--- a/frontend/src/components/StoryTile/StoryTile.js
+++ b/frontend/src/components/StoryTile/StoryTile.js
@@ -36,6 +36,25 @@ const InfoText = styled.div`
     }
 `
 
+const Categories = styled.div`
+    margin-top: 10px;
+`;
+
+const CategoryTag = styled.span`
+    display: inline-block;
+    background-color: #4a6e82;
+    color: white;
+    padding: 2px 8px;
+    margin-right: 5px;
+    border-radius: 3px;
+    font-size: 12px;
+
+    @media only screen and (max-width: 768px) {
+        font-size: 8px;
+        padding: 1px 4px;
+    }
+`;
+
 function StoryTile(props) {
     return (
         <Tile onClick={props.handleClick} className="tile">
@@ -50,6 +69,14 @@ function StoryTile(props) {
                 <Info>
                     <InfoText>{props.studentYear}</InfoText>
                     <InfoText>{props.studentMajor} Major</InfoText>
+                    {/* {props.categories.map((category, index) => (
+                            <InfoText key={index}>{category}</InfoText>
+                        ))} */}
+                    <Categories>
+                        {props.categories.map((category, index) => (
+                            <CategoryTag key={index}>{category}</CategoryTag>
+                        ))}
+                    </Categories>
                 </Info>
                 <TileIcon src={arrow} />
             </Link>

--- a/frontend/src/components/StoryTileGroup/StoryTileGroup.js
+++ b/frontend/src/components/StoryTileGroup/StoryTileGroup.js
@@ -36,6 +36,7 @@ function StoryTileGroup({ id, title, stories }) {
                                     ? story.StudentMajor
                                     : ''
                             }
+                            categories={story.RelevantCategoryList}
                             // buildingName={story.building}
                             // address={story.address}
                             // toExpect={story.whatToExpectList}

--- a/frontend/src/components/StoryTileGroup/StoryTileGroup.js
+++ b/frontend/src/components/StoryTileGroup/StoryTileGroup.js
@@ -11,9 +11,6 @@ import { StoryTile } from '../components'
 function StoryTileGroup({ id, title, stories }) {
     return (
         <TileGroupDiv>
-            <TitleContainer>
-                <Heading id={id}>{title}</Heading>
-            </TitleContainer>
             <TileGroup>
                 {stories.map((story, index) => {
                     return (

--- a/frontend/src/pages/StoriesPage/StoriesPage.js
+++ b/frontend/src/pages/StoriesPage/StoriesPage.js
@@ -11,6 +11,7 @@ function StoriesPage({ setActiveLink }) {
     const [stories, setStories] = useState([])
     const [idToName, setIdToName] = useState({})
     const [categoryNames, setCategoryNames] = useState([])
+    const [selectedCategory, setSelectedCategory] = useState('')
 
     useEffect(() => {
         // URL_PATH imported from frontend/src/links.js
@@ -53,6 +54,14 @@ function StoriesPage({ setActiveLink }) {
         setActiveLink('/Stories')
     }, [])
     
+    const handleCategoryChange = (category) => {
+        setSelectedCategory(category)
+    }
+
+    const filteredStories = selectedCategory 
+    ? stories.filter(story => story.RelevantCategoryList.includes(selectedCategory)) 
+    : stories
+
 
 
     return (
@@ -64,13 +73,13 @@ function StoriesPage({ setActiveLink }) {
             <DropDownForm
                 fieldTitle="Categories"
                 myoptions={categoryNames}
-                // handleChange={handleYearChange}
+                handleChange={handleCategoryChange}
             />
             <StoryTileGroup
                 key="all-stories"
                 id="all-stories"
                 title="All Stories"
-                stories={stories}
+                stories={filteredStories}
             />
         </div>
     )

--- a/frontend/src/pages/StoriesPage/StoriesPage.js
+++ b/frontend/src/pages/StoriesPage/StoriesPage.js
@@ -3,6 +3,7 @@ import {
     StoryBanner,
     CategoryButtonGroup,
     StoryTileGroup,
+    DropDownForm
 } from '../../components/components'
 import URL_PATH from '../../links'
 
@@ -10,6 +11,7 @@ function StoriesPage({ setActiveLink }) {
     const [stories, setStories] = useState([])
     const [nameToID, setNameToID] = useState({})
     const [categorNames, setCategorNames] = useState([])
+    const allStories = Object.values(nameToID).flat().map(id => stories[id]);
 
     useEffect(() => {
         // URL_PATH imported from frontend/src/links.js
@@ -54,6 +56,7 @@ function StoriesPage({ setActiveLink }) {
         setActiveLink('/Stories')
     }, [])
 
+
     return (
         <div>
             <StoryBanner
@@ -65,7 +68,20 @@ function StoriesPage({ setActiveLink }) {
                 names={categorNames}
                 locations={categorNames}
             />
-            {categorNames.map((name, index) => {
+            <DropDownForm
+                fieldTitle="Categories"
+                myoptions={categorNames}
+                // handleChange={handleYearChange}
+            />
+
+            <StoryTileGroup
+                key="all-stories"
+                id="all-stories"
+                title="All Stories"
+                stories={allStories}
+            />
+
+            {/* {categorNames.map((name, index) => {
                 let result = nameToID[name].map((id, index2) => stories[id])
                 return (
                     <StoryTileGroup
@@ -75,7 +91,7 @@ function StoriesPage({ setActiveLink }) {
                         stories={result}
                     />
                 )
-            })}
+            })} */}
         </div>
     )
 }

--- a/frontend/src/pages/StoriesPage/StoriesPage.js
+++ b/frontend/src/pages/StoriesPage/StoriesPage.js
@@ -11,7 +11,6 @@ function StoriesPage({ setActiveLink }) {
     const [stories, setStories] = useState([])
     const [nameToID, setNameToID] = useState({})
     const [categorNames, setCategorNames] = useState([])
-    const allStories = Object.values(nameToID).flat().map(id => stories[id]);
 
     useEffect(() => {
         // URL_PATH imported from frontend/src/links.js
@@ -40,14 +39,9 @@ function StoriesPage({ setActiveLink }) {
         fetch(URL_PATH + subdirectory)
             .then((response) => response.json())
             .then((json) => {
-                // Create a dictionary using subresource id as the key
-                // mapping to the full subresource object.
-                let tempDict = {}
-                tempDict = json.reduce((acc, obj) => {
-                    acc[obj._id] = obj
-                    return acc
-                }, {})
-                setStories(tempDict)
+                // Create a list of all stories
+                const allStories = json.map(obj => obj);
+                setStories(allStories);
             })
             .catch((error) => console.error(error))
     }, [])
@@ -78,7 +72,7 @@ function StoriesPage({ setActiveLink }) {
                 key="all-stories"
                 id="all-stories"
                 title="All Stories"
-                stories={allStories}
+                stories={stories}
             />
 
             {/* {categorNames.map((name, index) => {

--- a/frontend/src/pages/StoriesPage/StoriesPage.js
+++ b/frontend/src/pages/StoriesPage/StoriesPage.js
@@ -57,11 +57,11 @@ function StoriesPage({ setActiveLink }) {
                 imageUrl="https://images.unsplash.com/photo-1506962240359-bd03fbba0e3d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2065&q=80"
                 displayButton="true"
             />
-            <CategoryButtonGroup
+            {/* <CategoryButtonGroup
                 title="Categories"
                 names={categorNames}
                 locations={categorNames}
-            />
+            /> */}
             <DropDownForm
                 fieldTitle="Categories"
                 myoptions={categorNames}

--- a/frontend/src/pages/StoriesPage/StoriesPage.js
+++ b/frontend/src/pages/StoriesPage/StoriesPage.js
@@ -9,8 +9,8 @@ import URL_PATH from '../../links'
 
 function StoriesPage({ setActiveLink }) {
     const [stories, setStories] = useState([])
-    const [nameToID, setNameToID] = useState({})
-    const [categorNames, setCategorNames] = useState([])
+    const [idToName, setIdToName] = useState({})
+    const [categoryNames, setCategoryNames] = useState([])
 
     useEffect(() => {
         // URL_PATH imported from frontend/src/links.js
@@ -19,15 +19,14 @@ function StoriesPage({ setActiveLink }) {
         fetch(URL_PATH + subdirectory)
             .then((response) => response.json())
             .then((json) => {
-                let tempArray = []
-                let tempNameToID = {}
-                for (let object in json) {
-                    let name = json[object]['Title']
-                    tempArray.push(name)
-                    tempNameToID[name] = json[object]['StoryIDList']
-                }
-                setNameToID(tempNameToID)
-                setCategorNames(tempArray)
+                let tempCategoryNames = []
+                let tempIdToName = {}
+                json.forEach(category => {
+                    tempIdToName[category['_id']] = category['Title']
+                    tempCategoryNames.push(category['Title'])
+                })
+                setIdToName(tempIdToName)
+                setCategoryNames(tempCategoryNames)
             })
             .catch((error) => console.error(error))
     }, [])
@@ -40,15 +39,20 @@ function StoriesPage({ setActiveLink }) {
             .then((response) => response.json())
             .then((json) => {
                 // Create a list of all stories
-                const allStories = json.map(obj => obj);
+                const allStories = json.map(story => ({
+                    ...story,
+                    RelevantCategoryList: story.RelevantCategoryList.map(catId => idToName[catId] || catId)
+                }))              
+                console.log("all stories", allStories)
                 setStories(allStories);
             })
             .catch((error) => console.error(error))
-    }, [])
+    }, [idToName])
 
     useEffect(() => {
         setActiveLink('/Stories')
     }, [])
+    
 
 
     return (
@@ -57,35 +61,17 @@ function StoriesPage({ setActiveLink }) {
                 imageUrl="https://images.unsplash.com/photo-1506962240359-bd03fbba0e3d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2065&q=80"
                 displayButton="true"
             />
-            {/* <CategoryButtonGroup
-                title="Categories"
-                names={categorNames}
-                locations={categorNames}
-            /> */}
             <DropDownForm
                 fieldTitle="Categories"
-                myoptions={categorNames}
+                myoptions={categoryNames}
                 // handleChange={handleYearChange}
             />
-
             <StoryTileGroup
                 key="all-stories"
                 id="all-stories"
                 title="All Stories"
                 stories={stories}
             />
-
-            {/* {categorNames.map((name, index) => {
-                let result = nameToID[name].map((id, index2) => stories[id])
-                return (
-                    <StoryTileGroup
-                        key={name}
-                        id={name}
-                        title={name}
-                        stories={result}
-                    />
-                )
-            })} */}
         </div>
     )
 }


### PR DESCRIPTION
Before, the stories page was divided into different categories with a divider. Now, they are all under one section but have tags in the story tile.
<img width="1017" alt="Screenshot 2024-06-03 at 2 49 10 PM" src="https://github.com/CS-Social-Good-CalPoly/Vera/assets/55379287/950dac93-a407-4bbf-9919-8e4591920370">

Additionally, the page filters stories based on the category that the user selects with this dropdown. For example, selecting "School" will show all the stories that have one of the categories being "School."

<img width="1095" alt="Screenshot 2024-06-03 at 2 49 58 PM" src="https://github.com/CS-Social-Good-CalPoly/Vera/assets/55379287/dd870645-f753-4ef5-96e5-f4f50f05e4fc">
<img width="1175" alt="Screenshot 2024-06-03 at 2 49 48 PM" src="https://github.com/CS-Social-Good-CalPoly/Vera/assets/55379287/93c669f9-862d-4b25-8329-154bf64f0136">

I didn't have time to do the sorting by category, but I can probably do it another time! 
