### PR TITLE
center background so banner covers entire container

### DIFF
--- a/frontend/src/components/Banner/Banner.js
+++ b/frontend/src/components/Banner/Banner.js
@@ -9,6 +9,7 @@ function Banner(props) {
                 backgroundImage: `url(${props.imageUrl})`,
                 backgroundSize: 'cover',
                 backgroundRepeat: 'no-repeat',
+                backgroundPosition: 'center',
             }}
         >
             <div className="textCol">


### PR DESCRIPTION
Closes #300 

### Pull Request Summary

Fixed background style so that images are now correctly displayed in the banner 

### Screenshots/Screencast
<img width="1285" alt="Screenshot 2025-01-13 at 5 49 24 PM" src="https://github.com/user-attachments/assets/418a8700-5d19-47b2-bd64-9165e4307e52" />


