### PR TITLE
Add conditional RelevantCategoryList in fetch

### DIFF
--- a/frontend/src/pages/StoriesPage/StoriesPage.js
+++ b/frontend/src/pages/StoriesPage/StoriesPage.js
@@ -63,9 +63,11 @@ function StoriesPage({ setActiveLink }) {
                 // Create a list of all stories
                 const allStories = json.map((story) => ({
                     ...story,
-                    RelevantCategoryList: story.RelevantCategoryList.map(
-                        (catId, index) => idToName[catId] || catId,
-                    ),
+                    RelevantCategoryList: story.RelevantCategoryList
+                        ? story.RelevantCategoryList.map(
+                              (catId, index) => idToName[catId] || catId,
+                          )
+                        : [],
                 }))
                 setStories(allStories)
             })
@@ -116,9 +118,11 @@ function StoriesPage({ setActiveLink }) {
                 // Create a list of all stories
                 const allStories = json.map((story) => ({
                     ...story,
-                    RelevantCategoryList: story.RelevantCategoryList.map(
-                        (catId, index) => idToName[catId] || catId,
-                    ),
+                    RelevantCategoryList: story.RelevantCategoryList
+                        ? story.RelevantCategoryList.map(
+                              (catId, index) => idToName[catId] || catId,
+                          )
+                        : [],
                 }))
                 console.log(allStories)
                 // eventually, set state to this result


### PR DESCRIPTION
Fixed issue where the stories no longer loaded. A recent update to our backend deployment (Render) broke some of the code, especially in conjunction with our database cleanup. Some `stories` had an undefined `RelevantCategoryList`, which cased the fetch to fail. This PR adds a condition to only use the `map` function on `RelevantCategoryList` if the array exists, otherwise, `[]` is the default.