### PR TITLE
328 sti testing scraper

### DIFF
--- a/backend/routes/web_scraping.js
+++ b/backend/routes/web_scraping.js
@@ -1670,7 +1670,7 @@ router.put('/sti-testing', async (req, res) => {
         })
 
         const updatedResource = await IndResources.findByIdAndUpdate(
-            { _id: suicide_prevention_id },
+            { _id: sti_testing_id },
             newResource,
             { new: true, upsert: true },
         )

--- a/backend/routes/web_scraping.js
+++ b/backend/routes/web_scraping.js
@@ -1530,4 +1530,198 @@ router.put('/lets-talk', async (req, res) => {
     }
 })
 
+/* -------------------- STI TESTING -------------------- */
+router.post('/sti-testing', async (req, res) => {
+    try {
+        const response = await axios.get('https://chw.calpoly.edu/sti-testing')
+        const $ = cheerio.load(response.data)
+        // For now we are going to hardcode the suicide_prevention_id
+        // let suicide_prevention_id = '6804992335e3fe0a7c60b7c6'
+
+        // Extract header information
+        // Specifically for this site, take the first part of title since it's repetittive
+        const title =
+            $('meta[property="og:title"]')
+                .attr('content')
+                .split('|')[0]
+                .trim() ||
+            $('title').text().trim() ||
+            $('meta[name="title"]').attr('content')
+        const url = $('meta[property="og:url"]').attr('content')
+
+        // Extract image information
+        const image = $('h2[id="If_You_Are_Having_Thoughts_of_Suicide"]')
+            .children('img')
+            .attr('src')
+        const image_alt =
+            $('h2[id="If_You_Are_Having_Thoughts_of_Suicide"]')
+                .children('img')
+                .attr('alt') || 'Suicide Prevention Image' // Hardcode alt text since banner has none
+
+        // Regex for extracting phone numbers, emails, and days of the week
+        const daysRegex =
+            /\b(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)\b/
+
+        const phoneRegex =
+            /(\+?\d{1,3}[-.\s]?)?(\(?\d{3}\)?[-.\s]?)?\d{3}[-.\s]?\d{4}/g
+        // Note: modified so that first character cannot be a number (specific to Cal Fresh)
+        const emailRegex =
+            /[a-zA-Z][a-zA-Z0-9._%+-]*@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g
+
+        // Regex for extracting building
+        const buildingRegex = /(Building\b) (\w+)/
+        // Regex for extracting hours
+        const hoursRegex =
+            /(\d{1,2}(:\d{2})?\s?(AM|PM))\s?-\s?(\d{1,2}(:\d{2})?\s?(AM|PM))\s?\|\s?([A-Za-z,-]+)/i
+
+        // Extract info bar information
+        let column_info = []
+        let phoneNum = ''
+        let email = ''
+        let list_of_hours = []
+        let location = ''
+
+        console.log(title)
+        console.log(url)
+        console.log(image)
+        console.log(image_alt)
+        console.log(column_info)
+        console.log(phoneNum)
+        console.log(email)
+        console.log(list_of_hours)
+        console.log(location)
+
+        // $('div[id="rightCol"]')
+        //     .children('div[id="block-block-13"]')
+        //     .children('p')
+        //     .each((_index, element) => {
+        //         let $column_info_text = $(element).text().trim()
+        //         if (buildingRegex.test($column_info_text)) {
+        //             location = $column_info_text.match(buildingRegex)[0]
+        //             // We know the rest of the information is hours info
+        //             // extract this and put into the list_of_hours array
+        //             $column_info_text = $column_info_text
+        //                 .replace(location, '')
+        //                 .trim()
+        //             const formattedDate = formatHours1(
+        //                 $column_info_text.match(hoursRegex)[0],
+        //             )
+
+        //             list_of_hours.push(formattedDate)
+        //         } else if (daysRegex.test($column_info_text)) {
+        //             // If a day of the week is found : (likely for list of hours)
+        //             const formattedDate = $column_info_text
+        //                 .split('\n') // Split by newline for multiple ranges
+        //                 .map(formatHours) // Format each part
+        //                 .join(' \n') // Join them back with a newline
+        //             list_of_hours.push(formattedDate)
+        //         }
+        //         if (
+        //             phoneRegex.test($column_info_text) ||
+        //             emailRegex.test($column_info_text)
+        //         ) {
+        //             // Check if phone number or email is found
+        //             phoneNum = $column_info_text.match(phoneRegex)[0]
+        //             email = $column_info_text.match(emailRegex)[0]
+        //         } else {
+        //             // Any other footer info we can put extract
+        //             column_info.push($(element).text().trim())
+        //         }
+        //     })
+
+        // // Extract main text information
+        // const mainText = []
+        // const extraInfo = []
+
+        // $('div[class="field-item even"]')
+        //     .find('p')
+        //     .each((_index, element) => {
+        //         const $paragraphText = $(element)
+        //         // Finds the paragraph that starts with the respective title
+        //         if (
+        //             $paragraphText.find('strong') &&
+        //             $paragraphText
+        //                 .find('strong')
+        //                 .text()
+        //                 .trim()
+        //                 .startsWith('Contact someone who can help NOW. Call ')
+        //         ) {
+        //             // This is the paragraphText
+        //             mainText.push('If You Are Having Thoughts of Suicide ')
+        //             mainText.push($paragraphText.text().trim())
+        //         } else if (
+        //             $paragraphText
+        //                 .text()
+        //                 .trim()
+        //                 .startsWith('Students often face challenges')
+        //         ) {
+        //             mainText.push($paragraphText.text().trim())
+        //         }
+        //         // Conditions for finding ExtraInfo text
+        //         else if (
+        //             // hard-code the section header
+        //             $paragraphText.find('img') &&
+        //             $paragraphText.find('img').attr('src') ==
+        //                 'https://content-calpoly-edu.s3.amazonaws.com/chw/1/images/7_1.png'
+        //         ) {
+        //             const $ul = $paragraphText.next('ul')
+        //             $ul.find('li').each((_i, li) => {
+        //                 extraInfo.push($(li).text().trim())
+        //             })
+        //         } else if (
+        //             // hard-code the section header
+        //             $paragraphText.find('img') &&
+        //             $paragraphText.find('img').attr('src') ==
+        //                 'https://content-calpoly-edu.s3.amazonaws.com/chw/1/images/7_2.png'
+        //         ) {
+        //             const $nextP = $paragraphText.nextAll('p')
+        //             $nextP.each((_i, p) => {
+        //                 const $nextA = $(p).find('a').first()
+        //                 const text = $nextA.text().trim()
+
+        //                 // Filter out empty links or phone numbers
+        //                 if (text) {
+        //                     extraInfo.push(text)
+        //                 }
+        //             })
+        //         }
+        //     })
+
+        // const currentTime = new Date()
+
+        // // Store the resourceData into the database
+        // const newResource = new IndResources({
+        //     _id: suicide_prevention_id,
+        //     Title: title,
+        //     ImageURL: image,
+        //     ImageAltText: image_alt,
+        //     Address: location,
+        //     BuildingName: location,
+        //     ParagraphText: mainText.join('\n'),
+        //     PhoneNumber: phoneNum,
+        //     ResourceURL: url,
+        //     LastUpdate: currentTime,
+        //     Category: 'Self-Help',
+        //     ListOfHours: list_of_hours,
+        //     ExtraInfo: extraInfo,
+        // })
+
+        // const updatedResource = await IndResources.findByIdAndUpdate(
+        //     { _id: suicide_prevention_id },
+        //     newResource,
+        //     { new: true, upsert: true },
+        // )
+
+        // if (!updatedResource) {
+        //     return res.status(404).send('Resource not found')
+        // }
+
+        // // Respond with the updated resource
+        // res.json(newResource)
+    } catch (error) {
+        console.error('Scrapping failed:', error)
+        res.status(500).send('Error fetching Suicide Prevention data')
+    }
+})
+
 module.exports = router

--- a/backend/routes/web_scraping.js
+++ b/backend/routes/web_scraping.js
@@ -1536,7 +1536,7 @@ router.put('/sti-testing', async (req, res) => {
         const response = await axios.get('https://chw.calpoly.edu/sti-testing')
         const $ = cheerio.load(response.data)
         // For now we are going to hardcode the suicide_prevention_id
-        const suicide_prevention_id = '6823e7b999f0f8a3c5c5dc69'
+        const sti_testing_id = '6823e7b999f0f8a3c5c5dc69'
 
         // Extract header information
         // Specifically for this site, take the first part of title since it's repetittive
@@ -1654,7 +1654,7 @@ router.put('/sti-testing', async (req, res) => {
 
         // Store the resourceData into the database
         const newResource = new IndResources({
-            _id: suicide_prevention_id,
+            _id: sti_testing_id,
             Title: title,
             ImageURL: image,
             ImageAltText: image_alt,


### PR DESCRIPTION
Closes #328 

Completed STI Testing Scraper. Note, this page follows a slightly different layout/format than many of the other web scrapers, the scraping for `ParagraphText` and `ExtraInfo` is a lot more specific and likely won't work if Cal Poly changes this site.

Initially ran this as a `POST` request through Postman to create the MongoDB document. Then, I copied the `ObjectId` it generated (`6823e7b999f0f8a3c5c5dc69`) and used that for the hard-coded `sti_testing_id` for future calls and changed it to a `PUT` function, as we'll be updating it instead of making new documents from now on.