### PR TITLE
Added AdminResources Tags

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -18,6 +18,7 @@ const resourceRoutes = require('./routes/resources')
 const storyRoutes = require('./routes/stories')
 const web_scraping = require('./routes/web_scraping')
 const colleges_scraper = require('./routes/colleges_scraper')
+const tagsRoutes = require('./routes/tags')
 
 // Middleware || routes
 app.use(bodyparser.json())
@@ -28,6 +29,7 @@ app.use('/resources', resourceRoutes)
 app.use('/stories', storyRoutes)
 app.use('/web_scraping', web_scraping)
 app.use('/colleges_scraper', colleges_scraper)
+app.use('/tags', tagsRoutes)
 
 // home page route
 app.get('/', (req, res) => {

--- a/backend/routes/tags.js
+++ b/backend/routes/tags.js
@@ -1,0 +1,76 @@
+const express = require('express')
+const router = express.Router()
+const IndResources = require('../models/IndividualResources')
+
+/**
+ * POST route to add a tag to a resource
+ * Requires: resourceId and tag in the request body
+ */
+router.post('/add', async (req, res) => {
+    try {
+        const { resourceId, tag } = req.body
+
+        // Find the resource by ID
+        const resource = await IndResources.findById(resourceId)
+
+        // Check if the resource exists
+        const tagExists = resource.Tags.some(t => t.toLowerCase() === tag.toLowerCase())
+
+        // Raise error if the tag already exists to avoid duplicates
+        if (tagExists) {
+            return res.status(409).json({ message: 'Tag already exists for this resource' })
+        }
+
+        // Add the tag to the resource
+        if (!resource.Tags) {
+            resource.Tags = [tag]
+        } else {
+            resource.Tags.push(tag)
+        }
+
+        // Save the updated resource
+        await resource.save()
+
+        // Return the updated resource
+        return res.status(201).json({ 
+            message: 'Tag added successfully',
+            resource: resource
+        })
+
+    } catch (err) {
+        console.error('Error adding tag:', err)
+        return res.status(500).json({ message: err.message })
+    }
+})
+
+/**
+ * DELETE route to remove a tag from a resource
+ * Requires: resourceId and tag in the request parameters
+ */
+router.delete('/remove/:resourceId/:tag', async (req, res) => {
+    try {
+        const { resourceId, tag } = req.params
+
+        // Find the resource by ID
+        const resource = await IndResources.findById(resourceId)
+
+        // Remove the tag from the resource
+        resource.Tags = resource.Tags.filter(t => t !== tag)
+
+        // Save the updated resource
+        await resource.save()
+
+        // Return the updated resource
+        return res.status(200).json({ 
+            message: 'Tag removed successfully',
+            resource: resource
+        })
+
+    } catch (err) {
+        console.error('Error removing tag:', err)
+        return res.status(500).json({ message: err.message })
+    }
+})
+
+module.exports = router
+

--- a/frontend/src/components/ResourceTag/ResourceTag.js
+++ b/frontend/src/components/ResourceTag/ResourceTag.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import './ResourceTag.css'
 import { Modal } from '../../components/components.js'
 
-const ResourceTag = ({tag, onDelete }) => {
+const ResourceTag = ({tag, resourceId, onDelete }) => {
     const [showModal, setShowModal] = useState(false)
 
     const handleDelete = () => {
@@ -10,7 +10,7 @@ const ResourceTag = ({tag, onDelete }) => {
     }
 
     const handleConfirmDelete = () => {
-        onDelete(tag)
+        onDelete(tag, resourceId)
         setShowModal(false)
     }
 
@@ -22,7 +22,7 @@ const ResourceTag = ({tag, onDelete }) => {
         <>
         {showModal && (
             <Modal
-                message={`Delete tag "${tag}"? (This action cannot be undone!)`}
+                message={`Delete tag "${tag}"?`}
                 onConfirm={handleConfirmDelete}
                 onCancel={handleCancelDelete}
             />

--- a/frontend/src/components/ResourceTag/ResourceTag.js
+++ b/frontend/src/components/ResourceTag/ResourceTag.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import './ResourceTag.css'
 import { Modal } from '../../components/components.js'
 
-const ResourceTag = ({ tag }) => {
+const ResourceTag = ({tag, onDelete }) => {
     const [showModal, setShowModal] = useState(false)
 
     const handleDelete = () => {
@@ -10,7 +10,7 @@ const ResourceTag = ({ tag }) => {
     }
 
     const handleConfirmDelete = () => {
-        // For now, we're just closing the modal
+        onDelete(tag)
         setShowModal(false)
     }
 

--- a/frontend/src/links.js
+++ b/frontend/src/links.js
@@ -1,6 +1,8 @@
 const PROTOCOL = 'http'
 const HOSTNAME = 'localhost'
 const PORT = '3001'
-const URL_PATH = 'https://vera-backend.onrender.com'
+// const URL_PATH = 'https://vera-backend.onrender.com'
 
+// Uncomment this when you are testing on localhost
+const URL_PATH = `${PROTOCOL}://${HOSTNAME}:${PORT}`
 export default URL_PATH

--- a/frontend/src/pages/AdminPage/AdminPages.css
+++ b/frontend/src/pages/AdminPage/AdminPages.css
@@ -130,3 +130,10 @@
     font-size: 14px;
     padding: 4px 8px;
 }
+
+.tag-error-message {
+    color: #dc3545;
+    font-size: 14px;
+    margin-left: 10px;
+    white-space: nowrap;
+}

--- a/frontend/src/pages/AdminPage/AdminPages.css
+++ b/frontend/src/pages/AdminPage/AdminPages.css
@@ -75,3 +75,58 @@
     box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.2);
     transform: scale(0.98);
 }
+
+.resource-tag-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.add-tag-button {
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 20px;
+    padding: 4px 8px;    
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.add-tag-button:hover {
+    background-color: #0069d9;
+}
+
+.new-tag-input {
+    padding: 4px 8px;
+    border: 1px solid;
+    border-radius: 100px;
+    font-size: 14px;
+    min-width: 120px;
+}
+
+.tag-dropdown {
+    position: absolute;
+    background-color: white;
+    border: 1px solid;
+    border-radius: 20px;
+    margin-top: 4px;
+    max-height: 200px;
+    overflow-y: auto;
+    width: 150px;
+}
+
+.tag-option {
+    padding: 8px 12px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.tag-option:hover {
+    background-color: #2374c57e;
+}
+
+.no-tags-text {
+    font-size: 14px;
+    padding: 4px 8px;
+}

--- a/frontend/src/pages/AdminPage/AdminResourcesPage.js
+++ b/frontend/src/pages/AdminPage/AdminResourcesPage.js
@@ -1,10 +1,9 @@
 import React, { useState, useEffect } from 'react'
 import URL_PATH from '../../links.js'
 import './AdminPages.css'
-import { Modal, ResourceTag } from '../../components/components.js'
+import { Modal, ResourceTag } from '../../components/components.js'    
 
-// Predefined list of tags
-const predefinedTags = [
+const predefinedTags = [ // Predefined list of tags
     'Food',
     'Mental Health',
     'Counseling',
@@ -16,13 +15,14 @@ const predefinedTags = [
 ]
 
 function AdminResourcesPage({ setActiveLink }) {
-    const [resources, setResources] = useState([])
-    const [showModal, setShowModal] = useState(false)
-    const [selectedResourceId, setSelectedResourceId] = useState('')
+    const [resources, setResources] = useState([]) // Store all resources
+    const [showModal, setShowModal] = useState(false) // Track if the delete modal is shown
     const [showTagInput, setShowTagInput] = useState(null) // Track which resource's tag input is shown
-    const [newTag, setNewTag] = useState('') // Store the new tag text
+    const [newTag, setNewTag] = useState('') // Stores the new tag text
     const [showTagDropdown, setShowTagDropdown] = useState(null) // Track which resource's tag dropdown is shown
+    const [tagError, setTagError] = useState(null) // Track tag error messages with resourceId
 
+    // Set the active link for the admin page
     useEffect(() => {
         setActiveLink('/AdminPages')
     }, [setActiveLink])
@@ -33,27 +33,29 @@ function AdminResourcesPage({ setActiveLink }) {
         fetch(URL_PATH + subdirectory)
             .then((response) => response.json())
             .then((json) => {
-                setResources(json)
+                setResources(json) // Store fetched resources in state
             })
             .catch((error) => console.error(error))
 
         return () => {}
     }, [])
 
+    // Delete resource function
     const handleDelete = (id) => {
-        // setSelectedResourceId(id)
         setShowModal(true)
     }
 
+    // Confirm delete function
     const handleConfirmDelete = () => {
-        // deleteResource(selectedResourceId)
         setShowModal(false)
     }
-
+    
+    // Cancel delete function
     const handleCancelDelete = () => {
         setShowModal(false)
     }
 
+    // Called when add tag button is clicked
     const handleAddTagClick = (resourceId) => {
         if (showTagInput === resourceId) {
             setShowTagInput(null) // Hide the input field if it's already shown
@@ -61,71 +63,135 @@ function AdminResourcesPage({ setActiveLink }) {
         } else {
             setShowTagInput(resourceId)
             setShowTagDropdown(resourceId) // Show the dropdown for this resource
+            setTagError(null) // Clear any error message
         }
     }
 
+    // Called when the user types in the tag input
     const handleTagChange = (e) => {
-        setNewTag(e.target.value)
-    }
-
-    const handleTagKeyDown = (e, resourceId) => {
-        if (e.key === 'Enter' && newTag.trim() !== '') {                
-            // Add the new tag to the resource
-            const updatedResources = resources.map((resource) => {
-                if (resource._id === resourceId) {
-                    if (resource.Tags && resource.Tags.includes(newTag.trim())) {
-                        return resource
-                    } else {
-                        return {
-                            ...resource,
-                            Tags: [...(resource.Tags || []), newTag.trim()],
-                        }
-                    }
-                }
-                return resource
-            })
-            setResources(updatedResources)
-            setNewTag('') // Clear the input
-            setShowTagInput(null) // Hide the input field
-            setShowTagDropdown(null) // Hide the dropdown
+        setNewTag(e.target.value) // Update the new tag state
+        // Clear error when the user starts typing again
+        if (tagError) {
+            setTagError(null)
         }
     }
 
-    const handleTagSelect = (tag, resourceId) => {
-        // Add the selected predefined tag to the resource
-        const updatedResources = resources.map((resource) => {
-            if (resource._id === resourceId) {
-                if (resource.Tags && resource.Tags.includes(tag)) {
-                    return resource
-                } else {
-                    return {
-                        ...resource,
-                        Tags: [...(resource.Tags || []), tag],
-                    }
+    // Called when the user presses a key in the tag input
+    const handleTagKeyDown = async (e, resourceId) => {
+        if (e.key === 'Enter' && newTag.trim() !== '') {
+            try {
+                // Reset error messages
+                setTagError(null); 
+                
+                // Call backend API to add the tag
+                const response = await fetch(`${URL_PATH}/tags/add`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ 
+                        resourceId: resourceId,
+                        tag: newTag.trim()
+                    })
+                });
+                
+                const data = await response.json();
+                
+                // Check if there was an error (status code 409 for duplicate)
+                if (response.status === 409) {
+                    setTagError({ resourceId, message: data.message });
+                    return;
                 }
+                
+                // Update the resources state with the response
+                const updatedResources = resources.map(resource => {
+                    // Check if the resource ID matches the one we are updating
+                    if (resource._id === resourceId) {
+                        return data.resource;
+                    }
+                    return resource;
+                });
+                
+                setResources(updatedResources); // Update the resources state to reflect the new tag
+                setNewTag(''); // Clear the input
+                setShowTagInput(null); // Hide the input field
+                setShowTagDropdown(null); // Hide the dropdown
+            } catch (error) {
+                console.error('Error adding tag:', error);
             }
-            return resource
-        })
-        setResources(updatedResources)
-        setShowTagDropdown(null) // Hide the dropdown
-        setShowTagInput(null) // Hide the input field
+        }
     }
 
-    const handleTagDelete = (tag, resourceId) => {
-        // Remove the tag from the resource
-        const updatedResources = resources.map((resource) => {
-            if (resource._id === resourceId) {
-                return {
-                    ...resource,
-                    Tags: (resource.Tags).filter(t => t !== tag)
-                }
+    // Called when a predefined tag is selected from the dropdown
+    const handleTagSelect = async (tag, resourceId) => {        
+        try {
+            // Reset any previous error messages
+            setTagError(null);
+            
+            // Call backend API to add the tag
+            const response = await fetch(`${URL_PATH}/tags/add`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    resourceId: resourceId,
+                    tag: tag
+                })
+            });
+            
+            const data = await response.json();
+            
+            // Check if there was an error (status code 409 for duplicate)
+            if (response.status === 409) {
+                setTagError({ resourceId, message: data.message });
+                return;
             }
-            return resource
-        })
-        setResources(updatedResources)
+            
+            // Update the resources state with the response
+            const updatedResources = resources.map(resource => {
+                // Check if the resource ID matches the one we are updating
+                if (resource._id === resourceId) {
+                    return data.resource;
+                }
+                return resource;
+            });
+            
+            setResources(updatedResources); // Update the resources state to reflect the new tag
+            setShowTagDropdown(null); // Hide the dropdown
+            setShowTagInput(null); // Hide the input field
+        } catch (error) {
+            console.error('Error adding tag:', error);
+        } 
+    }
+
+    // Called when a tag is deleted
+    const handleTagDelete = async (tag, resourceId) => {
+        try {
+            // Call backend API to remove the tag
+            const response = await fetch(`${URL_PATH}/tags/remove/${resourceId}/${encodeURIComponent(tag)}`, {
+                method: 'DELETE'  // Explicitly set the HTTP method to DELETE
+            });
+
+            const data = await response.json();
+            
+            // Update the resources state with the response
+            const updatedResources = resources.map(resource => {
+                // Check if the resource ID matches the one we are updating
+                if (resource._id === resourceId) {
+                    return data.resource;
+                }
+                return resource;
+            });
+            
+            setResources(updatedResources); // Update the resources state to reflect the removed tag
+        } catch (error) {
+            console.error('Error deleting tag:', error);
+        }
     }
 
     return (
+        // Modal to confirm deletion of RESOURCE
         <div className="admin-container">
             {showModal && (
                 <Modal
@@ -189,24 +255,27 @@ function AdminResourcesPage({ setActiveLink }) {
                             <strong>Tags:</strong>
                             <div className="resource-tag-container">
                                 {resource.Tags && resource.Tags.length > 0 ? (
-                                    resource.Tags.map((tag) => (
+                                    resource.Tags.map((tag, tagIndex) => (
+                                        // Create ResourceTag component for each tag
                                         <ResourceTag 
-                                            tag={tag} 
+                                            key={tagIndex} 
+                                            tag={tag}
+                                            resourceId={resource._id}
                                             onDelete={() => handleTagDelete(tag, resource._id)} 
                                         />
                                     ))
                                 ) : (
                                     <span className="no-tags-text">No tags</span>
                                 )}
-                                <button
+                                <button // Button to add a new tag
                                     className="add-tag-button"
-                                    onClick={() =>handleAddTagClick(resource._id)}
+                                    onClick={() =>handleAddTagClick(resource._id)} // Call function and pass resource ID
                                 >
                                     + Add Tag
                                 </button>
                                 {showTagInput === resource._id && (
                                     <div>
-                                        <input
+                                        <input // Input field to enter new tag 
                                             type="text"
                                             value={newTag}
                                             onChange={handleTagChange} // onChange automatically passes in the event
@@ -216,10 +285,14 @@ function AdminResourcesPage({ setActiveLink }) {
                                             placeholder="Enter new tag"
                                             className="new-tag-input"
                                         />
-                                        {showTagDropdown === resource._id && (
+                                        {tagError && tagError.resourceId === resource._id && ( // Show error message if tag is already added
+                                                <span className="tag-error-message">{tagError.message}</span>
+                                            )}
+                                        {showTagDropdown === resource._id && ( // Show dropdown with predefined tags
                                             <div className="tag-dropdown">
-                                                {predefinedTags.map((tag) => (
+                                                {predefinedTags.map((tag, idx) => (
                                                     <div
+                                                        key={idx}
                                                         className="tag-option"
                                                         onClick={() =>
                                                             handleTagSelect(tag, resource._id)


### PR DESCRIPTION
Issue #407 

Added the tagging feature for resources on the Admin Resources page, allowing admins to add, delete, and manage tags for resources.

### Tagging Functionality Enhancements:

* **Added support for adding and deleting tags**: The `ResourceTag` component now deletes tags. Admins can add new tags or select predefined tags from a dropdown. 
* **Predefined tags**: Have a predefined list of tags (e.g., "Food," "Mental Health") for easier selection when tagging resources. 
    - Admin can not add the same tag twice for one resource, whether they try to type it or select it multiple times. 
* **Removed sample tag logic**: Eliminated the logic that added sample tags based on resource categories or titles

<img width="383" alt="Screenshot 2025-05-16 at 1 53 47 AM" src="https://github.com/user-attachments/assets/f35b8c1d-c6eb-41be-9488-f0ee9aea00e7" />

<img width="796" alt="Screenshot 2025-05-16 at 1 54 03 AM" src="https://github.com/user-attachments/assets/c16afa71-d8df-47f3-9d74-0bde108f22d9" />

<img width="511" alt="Screenshot 2025-05-16 at 1 54 18 AM" src="https://github.com/user-attachments/assets/8fa2b842-b0a6-4b7c-ab62-ab855518398d" />

<img width="1223" alt="Screenshot 2025-05-16 at 1 54 32 AM" src="https://github.com/user-attachments/assets/f50455b6-d184-45b6-b8df-ce60a77a6603" />
