### PR TITLE
385 redesign stories page

### DIFF
--- a/frontend/src/components/Footer/Footer.css
+++ b/frontend/src/components/Footer/Footer.css
@@ -1,5 +1,5 @@
 .main-footer {
-    background-color: #4a6e82;
+    background-color: #48858D;
     color: white;
     font-family: poppins;
     height: 220px;

--- a/frontend/src/components/Shared/Tile.css
+++ b/frontend/src/components/Shared/Tile.css
@@ -93,7 +93,7 @@
     }
 
     .view-more-button img {
-        width: 30px;
+        width: 28px;
         height: 30px;
     }
 }

--- a/frontend/src/components/Shared/Tile.css
+++ b/frontend/src/components/Shared/Tile.css
@@ -58,3 +58,42 @@
     }
   }
   
+  .view-more-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    background-color: white;
+    color: black;
+    padding: 25px 30px;
+    border-radius: 20px;
+    font-size: 14px;
+    font-weight: 600;
+    text-transform: uppercase;
+    text-decoration: none;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    width: fit-content;
+    margin-top: auto;
+}
+
+.view-more-button:hover {
+    background-color: #3a5a6b;
+}
+
+.view-more-button img {
+    width: 16px;
+    height: 16px;
+}
+
+@media only screen and (max-width: 768px) {
+    .view-more-button {
+        font-size: 10px;
+        padding: 6px 12px;
+    }
+
+    .view-more-button img {
+        width: 30px;
+        height: 30px;
+    }
+}

--- a/frontend/src/components/Shared/Tile.js
+++ b/frontend/src/components/Shared/Tile.js
@@ -67,13 +67,13 @@ export const TileIcon = styled.img`
 export const TileTitle = styled.h1`
     padding: 0 14px;
     font-family: Poppins;
-    font-size: 20px;
+    font-size: 30px;
     font-style: normal;
     font-weight: 600;
     letter-spacing: 0.05em;
     text-transform: uppercase;
     color: black;
-    line-height: 1.2em;
+    line-height: 2.5em;
     margin-bottom: 10px;
 
     @media only screen and (max-width: 768px) {

--- a/frontend/src/components/Shared/Tile.js
+++ b/frontend/src/components/Shared/Tile.js
@@ -73,7 +73,7 @@ export const TileTitle = styled.h1`
     letter-spacing: 0.05em;
     text-transform: uppercase;
     color: black;
-    line-height: 2.5em;
+    line-height: 2.2em;
     margin-bottom: 10px;
 
     @media only screen and (max-width: 768px) {

--- a/frontend/src/components/Shared/Tile.js
+++ b/frontend/src/components/Shared/Tile.js
@@ -15,7 +15,8 @@ export const Tile = styled.div`
     justify-content: flex-start;
 
     @media only screen and (max-width: 768px) {
-        width: 150px;
+        // width: 150px;
+        width: 30000px;
         height: 125px;
         background: #ffffff;
         box-shadow: 4px 4px 15px rgba(114, 141, 149, 0.15);

--- a/frontend/src/components/Shared/Tile.js
+++ b/frontend/src/components/Shared/Tile.js
@@ -2,49 +2,61 @@ import styled from 'styled-components'
 
 export const Tile = styled.div`
     position: relative;
-    width: 280px;
-    height: 290px;
+    width: 1200px;
+    min-width: 1000px;
+    height: 220px;
     background: #ffffff;
     box-shadow: 4px 4px 15px rgba(114, 141, 149, 0.15);
     border-radius: 30px;
-    margin: 20px;
+    margin: 20px 0 20px 20px; /* Changed: reduced right margin to shift left */
     overflow: hidden;
     cursor: pointer;
     display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-
+    flex-direction: row;
+    align-items: stretch;
+    flex-shrink: 0;
+    max-width: none !important;
+    
+    /* New: fix position related to the viewport */
+    transform: translateX(0); /* Ensure no transformation is pushing it */
+    left: 0; /* Anchor to left */
+    
     @media only screen and (max-width: 768px) {
-        // width: 150px;
-        width: 30000px;
-        height: 125px;
-        background: #ffffff;
-        box-shadow: 4px 4px 15px rgba(114, 141, 149, 0.15);
+        flex-direction: column;
+        width: 300px;
+        min-width: auto;
+        height: auto;
         border-radius: 10px;
-        margin: 8px;
+        margin: 20px auto; /* Center on mobile */
     }
 `
 
 export const TileBanner = styled.img`
-    width: 280px;
-    height: 120px;
-    object-fit: cover;
-    margin-bottom: 8px;
+    width: 45%;
+    height: 100%;
+    object-fit: cover; /* This maintains aspect ratio */
+    object-position: center; /* Centers the image */
+    border-top-left-radius: 30px;
+    border-bottom-left-radius: 30px;
+    min-width: 400px; /* Ensure minimum width */
+    max-width: 500px; /* Maximum width */
 
     @media only screen and (max-width: 768px) {
-        margin-bottom: 5px;
-        width: 150px;
-        height: 57px;
+        width: 100%;
+        height: 150px;
+        min-width: unset; /* Remove min-width constraint */
+        max-width: unset; /* Remove max-width constraint */
+        border-top-right-radius: 10px;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
     }
 `
-
 export const TileIcon = styled.img`
     position: absolute;
-    left: 88%;
-    top: 88%;
+    right: 20px;
+    bottom: 20px;
     width: 15px;
     height: 15px;
-    align: right;
 
     @media only screen and (max-width: 768px) {
         width: 10px;
@@ -53,36 +65,21 @@ export const TileIcon = styled.img`
 `
 
 export const TileTitle = styled.h1`
-    position: relative;
-    bottom: 1.4px;
     padding: 0 14px;
     font-family: Poppins;
     font-size: 20px;
     font-style: normal;
     font-weight: 600;
     letter-spacing: 0.05em;
-    line-height: 30px;
-    text-align: left;
     text-transform: uppercase;
     color: black;
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    line-height: 1em;
-    max-height: 3em;
-    margin-bottom: 15px;
+    line-height: 1.2em;
+    margin-bottom: 10px;
 
     @media only screen and (max-width: 768px) {
+        font-size: 12px;
         padding: 0 6px;
-        font-weight: 600;
-        font-size: 10px;
-        line-height: 12px;
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-        line-height: 1em;
-        max-height: 2em;
-        margin-bottom: 10px;
+        margin-bottom: 5px;
     }
 `
+

--- a/frontend/src/components/Shared/TileGroup.js
+++ b/frontend/src/components/Shared/TileGroup.js
@@ -9,7 +9,7 @@ export const TileGroupDiv = styled.div`
 export const TitleContainer = styled.div`
     border-bottom: 5px solid black;
     display: inline-block;
-    min-width: 430px;
+    min-width: 4300px;
     align-self: flex-start;
 
     @media only screen and (max-width: 768px) {
@@ -39,31 +39,31 @@ export const TileGroup = styled.div`
     }
 `
 
-// export const Tiles = styled.div`
-//     display: flex;
-//     flex-direction: column;
-//     border: 1px solid #4A6E82;
-//     width: 280px;
-//     height: 280px;
-//     background: #FFFFFF;
-//     box-shadow: 4px 4px 15px rgba(114, 141, 149, 0.15);
-//     border-radius: 30px;
-//     margin: 20px;
-//     overflow: hidden;
-//     cursor:pointer;
+export const Tiles = styled.div`
+    display: flex;
+    flex-direction: column;
+    border: 1px solid #4A6E82;
+    width: 280px;
+    height: 280px;
+    background: #FFFFFF;
+    box-shadow: 4px 4px 15px rgba(114, 141, 149, 0.15);
+    border-radius: 30px;
+    margin: 20px;
+    overflow: hidden;
+    cursor:pointer;
 
-//     @media only screen and (max-width: 768px) {
-//         display: flex;
-//         flex-direction: column;
-//         border: 1px solid #4A6E82;
-//         width: 150px;
-//         height: 125px;
-//         background: #FFFFFF;
-//         box-shadow: 4px 4px 15px rgba(114, 141, 149, 0.15);
-//         border-radius: 10px;
-//         margin: 8px;
-//     }
-// `;
+    @media only screen and (max-width: 768px) {
+        display: flex;
+        flex-direction: column;
+        border: 1px solid #4A6E82;
+        width: 150px;
+        height: 125px;
+        background: #FFFFFF;
+        box-shadow: 4px 4px 15px rgba(114, 141, 149, 0.15);
+        border-radius: 10px;
+        margin: 8px;
+    }
+`;
 
 export const Heading = styled.h1`
     font-style: normal;

--- a/frontend/src/components/StoryTile/StoryTile.js
+++ b/frontend/src/components/StoryTile/StoryTile.js
@@ -5,6 +5,7 @@ import React from 'react'
 import { Tile, TileIcon, TileTitle, TileBanner } from '../Shared/Tile.js'
 import '../Shared/Tile.css'
 
+
 const Info = styled.div`
     padding: 0 20px;  /* Changed: removed top/bottom padding */
     display: flex;
@@ -78,16 +79,26 @@ function StoryTile(props) {
                     <TileTitle>{props.title}</TileTitle>
                     <Info>
                         <InfoText>{props.studentYear}</InfoText>
-                        <InfoText>{props.studentMajor} Major</InfoText>
-                        <Categories>
+                       <InfoText>{props.ParagraphText}</InfoText>
+                       {/* <InfoText>{story.ParagraphText}</InfoText> */}
+                        {/* <InfoText>{props.studentMajor} Major</InfoText> */}
+                        {/* <Categories>
                             {props.categories.map((category, index) => (
                                 <CategoryTag key={index}>{category}</CategoryTag>
                             ))}
-                        </Categories>
+                        </Categories> */}
                     </Info>
+                     <div className="button-container">
+                        <Link to={`/individualStory/${props.id}`} className="view-more-button">
+                            View More
+                            <img src={arrow} alt="arrow icon" />
+                        </Link>
+                    </div>
                 </div>
-                <TileIcon src={arrow} />
+                
+            {/* <TileIcon src={arrow} /> */}
             </Link>
+             
         </Tile>
     )
 }

--- a/frontend/src/components/StoryTile/StoryTile.js
+++ b/frontend/src/components/StoryTile/StoryTile.js
@@ -79,7 +79,7 @@ function StoryTile(props) {
                     <TileTitle>{props.title}</TileTitle>
                     <Info>
                         <InfoText>{props.studentYear}</InfoText>
-                       <InfoText>{props.ParagraphText}</InfoText>
+                       <InfoText>{props.paragraphText} description</InfoText>
                        {/* <InfoText>{story.ParagraphText}</InfoText> */}
                         {/* <InfoText>{props.studentMajor} Major</InfoText> */}
                         {/* <Categories>

--- a/frontend/src/components/StoryTile/StoryTile.js
+++ b/frontend/src/components/StoryTile/StoryTile.js
@@ -6,16 +6,15 @@ import { Tile, TileIcon, TileTitle, TileBanner } from '../Shared/Tile.js'
 import '../Shared/Tile.css'
 
 const Info = styled.div`
-    padding-left: 23px;
-    padding-right: 50px;
-    position: relative;
-    bottom: 5px;
+    padding: 0 20px;  /* Changed: removed top/bottom padding */
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;  /* Changed: align from top */
+    flex: 1;  /* Added: take available space */
 
     @media only screen and (max-width: 768px) {
-        padding-left: 10px;
-        padding-right: 15px;
-        position: relative;
-        bottom: 4px;
+        padding: 0 10px 10px 10px;
+        width: 100%;
     }
 `
 
@@ -63,21 +62,30 @@ function StoryTile(props) {
                     pathname: `/individualStory/${props.id}`,
                 }}
                 className="tile-link"
+                style={{ 
+                    display: 'flex',  // Added: make link a flex container
+                    width: '100%',    // Added: take full width
+                    height: '100%',   // Added: take full height
+                    position: 'relative' // Added: for absolute positioning of icon
+                }}
             >
                 <TileBanner src={props.imgUrl} alt={props.title} />
-                <TileTitle>{props.title}</TileTitle>
-                <Info>
-                    <InfoText>{props.studentYear}</InfoText>
-                    <InfoText>{props.studentMajor} Major</InfoText>
-                    {/* {props.categories.map((category, index) => (
-                            <InfoText key={index}>{category}</InfoText>
-                        ))} */}
-                    <Categories>
-                        {props.categories.map((category, index) => (
-                            <CategoryTag key={index}>{category}</CategoryTag>
-                        ))}
-                    </Categories>
-                </Info>
+                <div style={{ 
+                    display: 'flex', 
+                    flexDirection: 'column',
+                    width: '55%' 
+                }}>
+                    <TileTitle>{props.title}</TileTitle>
+                    <Info>
+                        <InfoText>{props.studentYear}</InfoText>
+                        <InfoText>{props.studentMajor} Major</InfoText>
+                        <Categories>
+                            {props.categories.map((category, index) => (
+                                <CategoryTag key={index}>{category}</CategoryTag>
+                            ))}
+                        </Categories>
+                    </Info>
+                </div>
                 <TileIcon src={arrow} />
             </Link>
         </Tile>

--- a/frontend/src/components/StoryTileGroup/StoryTileGroup.js
+++ b/frontend/src/components/StoryTileGroup/StoryTileGroup.js
@@ -5,7 +5,6 @@ import {
     Heading,
     TileGroup,
 } from '../Shared/TileGroup.js'
-
 import { StoryTile } from '../components.js'
 
 function StoryTileGroup({ id, title, stories }) {
@@ -26,16 +25,16 @@ function StoryTileGroup({ id, title, stories }) {
                                     ? story.ParagraphText
                                     : ''
                             }
-                            studentYear={
-                                story && story.StudentYear
-                                    ? story.StudentYear
-                                    : ''
-                            }
-                            studentMajor={
-                                story && story.StudentMajor
-                                    ? story.StudentMajor
-                                    : ''
-                            }
+                            // studentYear={
+                            //     story && story.StudentYear
+                            //         ? story.StudentYear
+                            //         : ''
+                            // }
+                            // studentMajor={
+                            //     story && story.StudentMajor
+                            //         ? story.StudentMajor
+                            //         : ''
+                            // }
                             categories={story.RelevantCategoryList}
                             // buildingName={story.building}
                             // address={story.address}

--- a/frontend/src/pages/StoriesPage/StoriesPage.css
+++ b/frontend/src/pages/StoriesPage/StoriesPage.css
@@ -52,7 +52,7 @@
     max-width: 1200px;
     margin: 0 auto;
     justify-content: center;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 300px)); 
+    /* grid-template-columns: repeat(auto-fit, minmax(300px, 300px));  */
 }
 
 @media (max-width: 767px) {
@@ -66,10 +66,14 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    flex-wrap: wrap; /* this helps on smaller screens */
-    padding: 0 1rem;
-    margin-bottom: 1rem;
+    flex-wrap: wrap;
+    padding: 0 20px; /* Remove fixed 4rem and use padding similar to grid gap */
+    margin: 0 auto 1rem auto;
+    width: 100%;
+    max-width: 1200px; /* Match story-grid max-width */
+    box-sizing: border-box; /* Ensures padding doesn't expand total width */
 }
+
 
 .header-text h1 {
     margin: 0;

--- a/frontend/src/pages/StoriesPage/StoriesPage.css
+++ b/frontend/src/pages/StoriesPage/StoriesPage.css
@@ -1,9 +1,3 @@
-.dropdown-container {
-    display: absolute;
-    width: 100%;
-    justify-content: center;
-}
-
 .dropdown-style {
     padding: 5px;
     padding-left: 10px;
@@ -49,4 +43,35 @@
 .custom-input:focus {
     border-radius: 20px;
     border: 2px solid rgba(0, 0, 0, 0.5); /* Show border only when active */
+}
+
+.story-grid {
+    display: grid;
+    gap: 20px;
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    justify-content: center;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 300px)); 
+}
+
+@media (max-width: 767px) {
+    .story-grid {
+        grid-template-columns: minmax(280px, 300px); /* Single fixed-width column on mobile */
+        justify-content: center;
+    }
+}
+
+.header-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap; /* this helps on smaller screens */
+    padding: 0 1rem;
+    margin-bottom: 1rem;
+}
+
+.header-text h1 {
+    margin: 0;
+    line-height: 1.2;
 }

--- a/frontend/src/pages/StoriesPage/StoriesPage.js
+++ b/frontend/src/pages/StoriesPage/StoriesPage.js
@@ -140,10 +140,43 @@ function StoriesPage({ setActiveLink }) {
 
     return (
         <div>
-            <StoryBanner
+            {/* <StoryBanner
                 imageUrl="https://images.unsplash.com/photo-1506962240359-bd03fbba0e3d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2065&q=80"
                 displayButton="true"
+            /> */}
+            <div className="header-row">
+    <div className="header-text">
+        <h1>Student</h1>
+        <h1>Stories</h1>
+    </div>
+    <div className="dropdown-container">
+        <div className="dropdown-style">
+            <Search />
+            <input
+                className="custom-input"
+                placeholder="Search for stories..."
+                onInput={(e) => filterStoriesBySearch(e)}
             />
+            <DropDownSelectForm
+                fieldTitle="All Categories"
+                myoptions={[
+                    { value: '', label: 'All Categories' },
+                    ...categoryNames.map((major) => ({
+                        value: major,
+                        label: major,
+                    })),
+                ]}
+                handleChange={handleCategoryChange}
+                customStyles={{
+                    margin: '2px 2px 2px 2px',
+                }}
+            />
+        </div>
+    </div>
+</div>
+
+            {/* <h1>Student</h1>
+            <h1>Stories</h1>
             <div className="dropdown-container">
                 <div className="dropdown-style mt-4 mx-4 justify-content-between">
                     <Search />
@@ -169,14 +202,15 @@ function StoriesPage({ setActiveLink }) {
                         }}
                     />
                 </div>
-            </div>
-
+            </div> */}
+            <div className="story-grid">
             <StoryTileGroup
                 key="all-stories"
                 id="all-stories"
                 title="All Stories"
                 stories={filteredStories}
             />
+        </div>
         </div>
     )
 }


### PR DESCRIPTION
Redesign Stories Page
 [#385]([https://github.com/CS-Social-Good-CalPoly/Vera/issues/385])
Followed the design from the Figma. Removed the banner, reformatted the story tiles, aligned the search bar. Edited the story tile to have title and a view more button. Currently, hardcoded description, due not being able to pull the description from the individual story.