### PR TITLE
add tags to fuse

### DIFF
--- a/frontend/src/pages/HomePage/HomePage.js
+++ b/frontend/src/pages/HomePage/HomePage.js
@@ -34,7 +34,10 @@ function HomePage({ setActiveLink }) {
                     Category: resource.Category,
                     Details: resource.ParagraphText,
                     Type: 'Resource',
+                    Tags: resource.Tags || [],
                 }))
+
+                console.log('allResources', allResources)
 
                 // Fetch stories
                 const resStories = await fetch(
@@ -116,7 +119,7 @@ function HomePage({ setActiveLink }) {
         ignoreLocation: false,
         ignoreFieldNorm: false,
         fieldNormWeight: 1,
-        keys: ['Title', 'Category', 'Details'],
+        keys: ['Tags', 'Title', 'Category', 'Details'],
     }
 
     // use fuse to search for resources


### PR DESCRIPTION
# closes #432 

- Pulled tags from backend along with the other resource data (resources - tags array attribute) 
- Add to fuse options  

Went into the admin pages and added food tag to national eating disorder resource. Now it shows up when I type food:
![image](https://github.com/user-attachments/assets/84493041-e142-42af-9f6a-ed804684c400)
