### PR TITLE
added authentication

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "@babel/plugin-transform-numeric-separator": "^7.24.7",
     "@babel/plugin-transform-optional-chaining": "^7.24.8",
     "@babel/plugin-transform-private-methods": "^7.25.4",
+    "@clerk/clerk-react": "^5.31.8",
     "@eslint/config-array": "^0.18.0",
     "@eslint/object-schema": "^2.1.4",
     "@rollup/plugin-terser": "^0.4.4",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,8 @@ import React from 'react'
 import { Route, Switch } from 'react-router-dom'
 import { Footer, NavBar } from './components/components.js'
 import { useState } from 'react'
+import { ProtectedRoute } from './components/Clerk/ProtectedRoute.js'
+import { SignInPage } from './components/Clerk/SignInPage.js'
 import {
     ResourcePage,
     StoriesPage,
@@ -68,19 +70,24 @@ function App() {
                             />
                         )}
                     />
-                    <Route
+                    <ProtectedRoute
                         exact
                         path="/AdminPages"
                         component={() => (
                             <AdminPages setActiveLink={setActiveLink} />
                         )}
                     />
-                    <Route
+                    <ProtectedRoute
                         exact
                         path="/AdminPages/resources"
                         component={() => (
                             <AdminResourcesPage setActiveLink={setActiveLink} />
                         )}
+                    />
+                    <Route
+                        exact
+                        path="/sign-in"
+                        component={() => <SignInPage />}
                     />
                 </Switch>
             </div>

--- a/frontend/src/components/Clerk/ProtectedRoute.js
+++ b/frontend/src/components/Clerk/ProtectedRoute.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { useUser } from '@clerk/clerk-react'
+import { Redirect, Route } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
+
+export const ProtectedRoute = ({ component: Component, ...rest }) => {
+    const { isLoaded, isSignedIn } = useUser()
+    const location = useLocation()
+
+    return (
+        <Route
+            {...rest}
+            render={(props) =>
+                !isLoaded ? (
+                    <div>Loading...</div>
+                ) : isSignedIn ? (
+                    <Component {...props} />
+                ) : (
+                    <Redirect
+                        to={{
+                            pathname: '/sign-in',
+                            state: { from: location },
+                        }}
+                    />
+                )
+            }
+        />
+    )
+}

--- a/frontend/src/components/Clerk/SignInPage.js
+++ b/frontend/src/components/Clerk/SignInPage.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { SignIn } from '@clerk/clerk-react'
+import { useLocation } from 'react-router-dom'
+
+export const SignInPage = () => {
+    const location = useLocation()
+
+    const from = location.state?.from?.pathname || '/AdminPages'
+
+    return (
+        <div
+            style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                minHeight: '75vh',
+                paddingTop: '2rem', // ✅ add space at the top
+                paddingBottom: '2rem', // ✅ add space at the bottom
+            }}
+        >
+            <div
+                style={{
+                    width: '100%',
+                    maxWidth: '28rem',
+                    margin: '0 auto',
+                }}
+            >
+                <SignIn path="/sign-in" routing="path" afterSignInUrl={from} />
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/components/Navbar/Navbar.js
+++ b/frontend/src/components/Navbar/Navbar.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Navbar, Nav } from 'react-bootstrap'
 import { NavLink, Link } from 'react-router-dom'
 import './Navbar.css'
+import { SignedIn, UserButton } from '@clerk/clerk-react'
 import logo from './VeraLogo.jpg'
 
 function NavBar({ activeLink }) {
@@ -24,9 +25,7 @@ function NavBar({ activeLink }) {
                     <NavLink
                         className="navbar-links"
                         to="/"
-                        activeClassName={
-                            activeLink === '/' ? 'active' : ''
-                        }
+                        activeClassName={activeLink === '/' ? 'active' : ''}
                     >
                         Home
                     </NavLink>
@@ -66,6 +65,11 @@ function NavBar({ activeLink }) {
                     >
                         Share Your Story
                     </NavLink>
+                    <div className="my-auto">
+                        <SignedIn>
+                            <UserButton />
+                        </SignedIn>
+                    </div>
                 </Nav>
             </Navbar.Collapse>
         </Navbar>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,11 +4,21 @@ import './index.css'
 import App from './App.js'
 import reportWebVitals from './reportWebVitals.js'
 import { BrowserRouter } from 'react-router-dom'
+import { ClerkProvider } from '@clerk/clerk-react'
+
+const PUBLISHABLE_KEY =
+    'pk_test_dmFsaWQtY2hpZ2dlci0zOC5jbGVyay5hY2NvdW50cy5kZXYk'
+
+if (!PUBLISHABLE_KEY) {
+    throw new Error('Missing Publishable Key')
+}
 
 ReactDOM.render(
     <React.StrictMode>
         <BrowserRouter>
-            <App />
+            <ClerkProvider publishableKey={PUBLISHABLE_KEY}>
+                <App />
+            </ClerkProvider>
         </BrowserRouter>
     </React.StrictMode>,
     document.getElementById('root'),

--- a/frontend/src/pages/AdminPage/AdminPages.js
+++ b/frontend/src/pages/AdminPage/AdminPages.js
@@ -3,6 +3,7 @@ import { Link, useHistory } from 'react-router-dom'
 import URL_PATH from '../../links.js'
 import './AdminPages.css'
 import { DropDownSelectForm, Modal } from '../../components/components.js'
+import { useUser } from '@clerk/clerk-react'
 
 function AdminPages({ setActiveLink }) {
     const [stories, setStories] = useState([])
@@ -12,6 +13,10 @@ function AdminPages({ setActiveLink }) {
     const [selectedStoryId, setSelectedStoryId] = useState('')
     const [categoryNames, setCategoryNames] = useState([])
     const history = useHistory()
+
+    const { user } = useUser()
+    console.log(user)
+    const isAdmin = user.publicMetadata.admin === 'true'
 
     useEffect(() => {
         let isMounted = true
@@ -54,6 +59,14 @@ function AdminPages({ setActiveLink }) {
     useEffect(() => {
         setActiveLink('/AdminPages')
     }, [setActiveLink, toggleStatus])
+
+    if (!isAdmin) {
+        return (
+            <div className="text-center pt-4">
+                You are not authorized to view this page.
+            </div>
+        )
+    }
 
     const handleFilter = (discipline) => {
         setSelectedDiscipline(discipline)


### PR DESCRIPTION
closes #429 

# Added Authentication
- Pretty much the same implementation as the last PR
- Wrapped the ClerkProvider around the entire <App/> and use ProtectedRoute on Admin Pages
- If we access AdminPages, it should redirect to signin page
- Clerk resources such as { SignInPage, ProtectedRoute } are under the Clerk folder
- We might need to test how it works on deployment branch (cuz maybe we need to include an API key) 

## From my understanding its ok to expose the frontend URL: 
![image](https://github.com/user-attachments/assets/7e8cc0ed-1d8b-46a4-aa1a-e8db23943470)

# After someone signs up they still need admin access
1) Login to Clerk through the Vera gmail account
2) Go to the dashboard and select the user
3) Go to public metadata and add: 
![image](https://github.com/user-attachments/assets/d616e5fb-1f1a-4616-a928-59cdf7b78d12)
4) Now we should be able to access admin pages

# Examples of signin/signup
![image](https://github.com/user-attachments/assets/fd842ed3-e3a5-4125-a6b0-9105c1177844)
![image](https://github.com/user-attachments/assets/98d18cbc-049b-4a93-8ab7-4d80d5f5bfc4)


